### PR TITLE
chore: switch to GitHub Flow, fix links, update README status

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -39,12 +39,24 @@ Commits in this repo use `hi@spaceduck.ai` as the author email (set via local gi
 - **Never commit binaries or build artifacts.** `dist/`, `node_modules/`, `*.db` are gitignored.
 - **Don't skip hooks.** Never use `--no-verify`.
 
-## Branch Strategy
+## Branch Strategy (GitHub Flow)
 
-- `main` — stable, always passes tests
+- `main` — stable, protected. All PRs target `main`. Never push directly.
 - Feature branches: `feat/<short-description>` (e.g., `feat/web-ui`)
 - Fix branches: `fix/<short-description>`
-- Keep branches short-lived. Merge via PR with squash.
+- Chore branches: `chore/<short-description>`
+- Keep branches short-lived. Merge via PR.
+
+### Starting a task
+
+**Always create a feature branch before making changes.** When the user asks you to implement something:
+
+1. `git checkout main && git pull origin main`
+2. `git checkout -b <type>/<short-description>` (e.g., `feat/config-system`, `fix/memory-leak`, `chore/update-deps`)
+3. Do the work, commit incrementally
+4. Push and tell the user to create a PR on GitHub
+
+Never commit directly to `main`. If you find yourself on `main`, create and switch to a branch first.
 
 ## When to Commit
 
@@ -53,7 +65,7 @@ Commit after completing a logical unit of work:
 - A new feature, test suite, or bug fix
 - A rename, refactor, or config change
 
-Do NOT commit half-finished work to `main`. Use a feature branch if needed.
+Do NOT commit half-finished work to `main`. Use a feature branch.
 
 ## Pull Requests
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Question or discussion
-    url: https://github.com/spaceduck-ai/spaceduck/discussions
+    url: https://github.com/maziarzamani/spaceduck/discussions
     about: Ask a question or start a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Before opening a feature request, check the [Roadmap](https://github.com/spaceduck-ai/spaceduck#roadmap) and open [discussions](https://github.com/spaceduck-ai/spaceduck/discussions) — it may already be planned or in progress.
+        Before opening a feature request, check the [Roadmap](https://github.com/maziarzamani/spaceduck#roadmap) and open [discussions](https://github.com/maziarzamani/spaceduck/discussions) — it may already be planned or in progress.
 
   - type: textarea
     id: summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   test:
@@ -54,16 +54,3 @@ jobs:
 
       - name: Run tests
         run: bun test --recursive
-
-  auto-approve:
-    name: Auto-approve PR (CI passed)
-    needs: [test]
-    runs-on: ubuntu-latest
-    # Only runs on PRs — not on direct pushes to main
-    if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: hmarr/auto-approve-action@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,22 +16,23 @@ Welcome. Spaceduck is a personal AI assistant built from scratch — no agent fr
 
 One PR = one topic. Do not bundle unrelated fixes or features. PRs over 500 changed lines get extra review time; if yours is large, explain why in the description.
 
-## Branching (Gitflow)
+## Branching (GitHub Flow)
+
+`main` is always stable and protected. All work happens on short-lived feature branches.
 
 | Branch | Purpose |
 |--------|---------|
-| `main` | Tagged releases only — never commit directly |
-| `develop` | Integration — all features land here |
-| `feature/*` | New work — branch from and PR back to `develop` |
-| `release/*` | Release prep — from `develop`, merges to `main` + `develop` |
-| `hotfix/*` | Urgent fixes — from `main`, merges to `main` + `develop` |
+| `main` | Stable, protected — all PRs target this branch |
+| `feat/*` | New features |
+| `fix/*` | Bug fixes |
+| `chore/*` | Tooling, deps, config |
 
 ### Day-to-day workflow
 
-1. `git checkout develop && git pull`
-2. `git checkout -b feature/your-thing`
+1. `git checkout main && git pull`
+2. `git checkout -b feat/your-thing`
 3. Commit with conventional prefixes (`feat:`, `fix:`, `chore:`…)
-4. Push and open a PR targeting `develop`
+4. Push and open a PR targeting `main`
 5. CI passes → auto-approved → merge
 
 ## Local setup

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Built from scratch with no agent frameworks or orchestration wrappers. Core laye
 | Context builder | ✅ | Token budgeting, system prompt injection, LTM fact recall, auto-compaction, afterTurn eager flush |
 | Agent loop | ✅ | Multi-round tool execution with automatic tool → result → LLM cycles |
 | Event bus | ✅ | Typed fire-and-forget + async emit, powers fact extraction pipeline |
+| Configuration system | 🔜 | Structured config file replacing `.env` — type-safe, nestable, multi-environment |
+| Plugin lifecycle | 🔜 | Standardized init/shutdown hooks for providers, channels, and tools |
+| Streaming protocol v2 | 🔜 | Structured envelopes for tool progress, memory events, and error recovery |
 
 ### Memory
 
@@ -46,6 +49,10 @@ Built from scratch with no agent frameworks or orchestration wrappers. Core laye
 | Fact extraction | ✅ | LLM-based with hardened JSON parsing, regex fallback, afterTurn eager flush |
 | Deduplication | ✅ | SHA-256 content hashing for exact duplicates |
 | Hybrid recall | ✅ | RRF combining vector cosine + FTS5 BM25, recency decay, SQL expiry pushdown |
+| Fact conflict resolution | 🔜 | Detect contradicting facts and prefer the most recent or highest-confidence version |
+| Backfill script | 🔜 | Resumable migration to embed existing unembedded facts |
+| Memory inspector | 🔜 | Web UI panel to browse, edit, and delete stored facts |
+| Per-user isolation | 🔜 | Scope facts by user identity across channels |
 
 ### Providers
 
@@ -57,6 +64,9 @@ Built from scratch with no agent frameworks or orchestration wrappers. Core laye
 | OpenRouter | ✅ | Multi-model chat streaming (access to hundreds of models) |
 | AWS Bedrock | ✅ | Native Converse API (required for Nova), Titan Text Embeddings V2, Bearer token auth |
 | Embedding factory | ✅ | Provider-agnostic creation from env config, fail-fast dimension validation |
+| Ollama | 🔜 | Local models via Ollama API |
+| Anthropic (direct) | 🔜 | Claude via Anthropic API (non-Bedrock) |
+| Provider fallback chain | 🔜 | Auto-retry with secondary provider on failure or timeout |
 
 ### Channels & Interface
 
@@ -68,6 +78,7 @@ Built from scratch with no agent frameworks or orchestration wrappers. Core laye
 | Discord | 🔜 | Discord bot channel |
 | Telegram | 🔜 | Telegram bot channel |
 | CLI | 🔜 | Terminal-based chat interface |
+| Multi-user auth | 🔜 | Token-based auth for Web UI, per-user sessions |
 
 ### Tools
 
@@ -75,8 +86,10 @@ Built from scratch with no agent frameworks or orchestration wrappers. Core laye
 |-----------|---|---------|
 | Browser | ✅ | Playwright headless with accessibility snapshot refs |
 | Web fetch | ✅ | HTTP fetch + HTML-to-text conversion |
-| Web search | 🔜 | Brave Search API integration |
+| Web search | 🔜 | Brave/SearXNG search API integration |
 | Scheduler | 🔜 | Periodic web monitoring with natural language conditions |
+| File system | 🔜 | Read/write local files with sandboxed access |
+| Code interpreter | 🔜 | Execute code snippets in a sandboxed runtime |
 
 ## What it does today
 
@@ -247,11 +260,13 @@ bun run bench
 
 ## Roadmap
 
-1. **Configuration system** — replace flat `.env` with a structured config file (`spaceduck.config.ts` or `spaceduck.yaml`). The current `.env` approach does not scale: no nesting, no type safety, no multi-environment support, and no way to express complex provider or memory configuration without a growing list of unrelated variables.
-2. **Web search tool** — search API integration for real-time information retrieval
-3. **Scheduler** — periodic web monitoring with natural language conditions
-4. **Backfill script** — resumable migration to embed existing facts
-5. **Skills system** — pluggable agent capabilities loaded from markdown definitions
+All planned features are tracked inline in the [Status](#status) tables above (marked 🔜). The highest-priority items right now:
+
+1. **Configuration system** — replace flat `.env` with a structured config file. The current approach does not scale: no nesting, no type safety, no multi-environment support.
+2. **Per-user isolation** — scope facts by user identity so multi-user setups don't leak memory across people.
+3. **Web search tool** — search API integration for real-time information retrieval.
+4. **Provider fallback chain** — auto-retry with a secondary provider on failure or timeout.
+5. **Memory inspector** — Web UI panel to browse, edit, and delete stored facts.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please do not open a public GitHub issue for security vulnerabilities.
 
-Report privately via **[GitHub Security Advisories](https://github.com/spaceduck-ai/spaceduck/security/advisories/new)**. This keeps the report confidential until a fix is ready.
+Report privately via **[GitHub Security Advisories](https://github.com/maziarzamani/spaceduck/security/advisories/new)**. This keeps the report confidential until a fix is ready.
 
 Include in your report:
 

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -9,7 +9,7 @@ export interface Fact {
   readonly content: string;
   readonly category?: string;
   /** Where the fact came from. */
-  readonly source: "auto-extracted" | "manual" | "compaction-flush";
+  readonly source: "auto-extracted" | "manual" | "compaction-flush" | "turn-flush";
   /** Confidence score 0-1 set by the firewall heuristic. */
   readonly confidence: number;
   /** Optional expiry timestamp (ms). NULL means never expires. */


### PR DESCRIPTION
- Remove auto-approve CI job and develop-to-main sync workflow
- Revert CI triggers to main-only
- Update CONTRIBUTING.md and git-workflow rule to GitHub Flow
- Fix broken GitHub links in SECURITY.md and issue templates
- Add planned features to README status tables with experimental warning
- Add "turn-flush" to Fact source union type (fixes typecheck)
- Add branch-creation instructions to Cursor git-workflow rule

## Summary

<!--
2-5 bullets: what problem this solves, what changed, what did NOT change.
-->

-
-

## Change type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## Linked issue

<!-- Closes #NNN  or  N/A -->

## Testing

<!-- How did you verify this works? What did you test? What did you NOT test? -->

- [ ] `bun test --recursive` passes
- [ ] `bun run typecheck` is clean
- [ ] `bun run build` succeeds
- [ ] Tested manually (describe below)

## Security impact

<!-- Does this change touch auth, credentials, network, file I/O, or LLM prompt construction? -->

- [ ] No security impact
- [ ] Yes — explain:

## AI-assisted

- [ ] This PR was fully or partly written with AI assistance (Cursor / Claude / Codex / other)
