### PR TITLE
chore: move DB to data/ dir and decouple desktop from gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,7 @@ GEMINI_API_KEY=
 
 # ── Memory ────────────────────────────────────────────────────────────────────
 MEMORY_BACKEND=sqlite                    # only sqlite is supported currently
-MEMORY_CONNECTION_STRING=spaceduck.db    # file path for SQLite, or :memory: for ephemeral
+MEMORY_CONNECTION_STRING=data/spaceduck.db    # file path for SQLite, or :memory: for ephemeral
 
 # ── Embedding / Vector Memory ────────────────────────────────────────────────
 # Enables semantic (cross-lingual) recall across conversations.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "ai.spaceduck.desktop",
   "build": {
     "beforeBuildCommand": "bun run build:all",
-    "beforeDevCommand": "bun run --cwd ../.. dev",
+    "beforeDevCommand": "",
     "devUrl": "http://localhost:3000",
     "frontendDist": "../dist"
   },


### PR DESCRIPTION
- Update MEMORY_CONNECTION_STRING default to data/spaceduck.db
- Remove beforeDevCommand from Tauri config so dev:desktop no longer starts the gateway (run separately with bun run dev)

## Summary

<!--
2-5 bullets: what problem this solves, what changed, what did NOT change.
-->

-
-

## Change type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## Linked issue

<!-- Closes #NNN  or  N/A -->

## Testing

<!-- How did you verify this works? What did you test? What did you NOT test? -->

- [ ] `bun test --recursive` passes
- [ ] `bun run typecheck` is clean
- [ ] `bun run build` succeeds
- [ ] Tested manually (describe below)

## Security impact

<!-- Does this change touch auth, credentials, network, file I/O, or LLM prompt construction? -->

- [ ] No security impact
- [ ] Yes — explain:

## AI-assisted

- [ ] This PR was fully or partly written with AI assistance (Cursor / Claude / Codex / other)
