### PR TITLE
docs: Mintlify documentation site + README rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 > [!WARNING]
-> **Experimental — APIs and storage may change before v1.0.**
+> **Experimental — Breaking changes before v1.0.**
 
 ---
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,4 +1,4 @@
-# Spaceduck Vision
+# spaceduck Vision
 
 Spaceduck is a personal AI assistant that runs locally or connects to cloud models.
 It is designed to feel trustworthy, fast, and always available, while keeping the user in control.


### PR DESCRIPTION
## Summary

- Scaffold Mintlify documentation site with 19 pages covering quickstart, architecture, providers, memory, tools, and platforms
- Rewrite README as a concise landing page pointing to the docs site for depth
- Add VISION.md as a north-star document for the project
- Add build/release/license/runtime badges

## Changes

- `docs/` — full Mintlify doc site (quickstart, architecture, providers, memory, tools, platforms)
- `README.md` — rewritten as landing page with badges, feature highlights, and docs link
- `VISION.md` — project north star
- `docs.json` — Mintlify configuration

## Test plan

- [ ] Verify Mintlify docs render correctly (`mintlify dev`)
- [ ] Check all internal links resolve
- [ ] Confirm badges display correctly on GitHub


Made with [Cursor](https://cursor.com)