### PR TITLE
chore: exclude website from release-please version bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "node",
       "package-name": "spaceduck",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "exclude-paths": ["apps/spaceduck-website"]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Adds `exclude-paths` for `apps/spaceduck-website` to release-please config
- Website-only commits will no longer trigger version bumps or releases

Made with [Cursor](https://cursor.com)