### PR TITLE
chore: update dependencies, pin versions, fix minimatch vulnerability

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,10 +17,10 @@
     "@spaceduck/ui": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "^1.3.9",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "bun-plugin-tailwind": "latest"
+    "bun-plugin-tailwind": "^0.1.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,8 +15,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.1.4",
-    "bun-plugin-tailwind": "latest",
-    "bun-types": "latest",
+    "bun-plugin-tailwind": "^0.1.2",
+    "bun-types": "^1.3.9",
     "tailwindcss": "^4",
     "vite": "^7.3.1"
   }

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,13 @@
   "workspaces": {
     "": {
       "name": "spaceduck",
+      "dependencies": {
+        "@tailwindcss/vite": "^4.2.1",
+      },
       "devDependencies": {
-        "bun-plugin-tailwind": "latest",
-        "bun-types": "latest",
-        "tailwindcss": "^4",
+        "bun-plugin-tailwind": "^0.1.2",
+        "bun-types": "^1.3.9",
+        "tailwindcss": "^4.2.1",
         "typescript": "^5",
       },
     },
@@ -32,8 +35,8 @@
       "devDependencies": {
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "bun-plugin-tailwind": "latest",
-        "bun-types": "latest",
+        "bun-plugin-tailwind": "^0.1.2",
+        "bun-types": "^1.3.9",
         "tailwindcss": "^4",
       },
     },
@@ -73,8 +76,8 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.1.4",
-        "bun-plugin-tailwind": "latest",
-        "bun-types": "latest",
+        "bun-plugin-tailwind": "^0.1.2",
+        "bun-types": "^1.3.9",
         "tailwindcss": "^4",
         "vite": "^7.3.1",
       },
@@ -85,12 +88,12 @@
       "dependencies": {
         "@hapi/boom": "^10",
         "@spaceduck/core": "workspace:*",
-        "@whiskeysockets/baileys": "latest",
+        "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "qrcode-terminal": "^0.12.0",
       },
       "devDependencies": {
         "@types/qrcode-terminal": "^0.12",
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/config": {
@@ -100,7 +103,7 @@
         "zod": "^3.25.0",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
         "typescript": "^5",
       },
     },
@@ -108,7 +111,7 @@
       "name": "@spaceduck/core",
       "version": "0.1.0",
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/gateway": {
@@ -132,7 +135,7 @@
         "@spaceduck/web": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
         "json5": "^2.2.3",
       },
     },
@@ -144,7 +147,7 @@
         "sqlite-vec": "^0.1.7-alpha.2",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
         "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",
       },
     },
@@ -155,18 +158,18 @@
         "@spaceduck/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/providers/gemini": {
       "name": "@spaceduck/provider-gemini",
       "version": "0.1.0",
       "dependencies": {
-        "@google/genai": "latest",
+        "@google/genai": "^1.42.0",
         "@spaceduck/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/providers/llamacpp": {
@@ -177,7 +180,7 @@
         "@spaceduck/provider-openai-compat": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/providers/lmstudio": {
@@ -188,7 +191,7 @@
         "@spaceduck/provider-openai-compat": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/providers/openai-compat": {
@@ -198,42 +201,42 @@
         "@spaceduck/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/providers/openrouter": {
       "name": "@spaceduck/provider-openrouter",
       "version": "0.1.0",
       "dependencies": {
-        "@openrouter/sdk": "latest",
+        "@openrouter/sdk": "^0.8.0",
         "@spaceduck/core": "workspace:*",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/stt/whisper": {
       "name": "@spaceduck/stt-whisper",
       "version": "0.1.0",
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/tools/browser": {
       "name": "@spaceduck/tool-browser",
       "version": "0.1.0",
       "dependencies": {
-        "playwright": "latest",
+        "playwright": "^1.58.2",
       },
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/tools/marker": {
       "name": "@spaceduck/tool-marker",
       "version": "0.1.0",
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/tools/web-fetch": {
@@ -244,14 +247,14 @@
       },
       "devDependencies": {
         "@types/html-to-text": "^9",
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/tools/web-search": {
       "name": "@spaceduck/tool-web-search",
       "version": "0.1.0",
       "devDependencies": {
-        "bun-types": "latest",
+        "bun-types": "^1.3.9",
       },
     },
     "packages/ui": {
@@ -270,22 +273,25 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@spaceduck/core": "workspace:*",
-        "class-variance-authority": "latest",
-        "clsx": "latest",
-        "lucide-react": "latest",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.575.0",
         "react": "^19",
         "react-dom": "^19",
-        "react-markdown": "latest",
-        "tailwind-merge": "latest",
+        "react-markdown": "^10.1.0",
+        "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "bun-plugin-tailwind": "latest",
-        "bun-types": "latest",
+        "bun-plugin-tailwind": "^0.1.2",
+        "bun-types": "^1.3.9",
         "tailwindcss": "^4",
       },
     },
+  },
+  "overrides": {
+    "minimatch": "^10.2.2",
   },
   "packages": {
     "@antfu/ni": ["@antfu/ni@25.0.0", "", { "dependencies": { "ansis": "^4.0.0", "fzf": "^0.5.2", "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" }, "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs", "nup": "bin/nup.mjs" } }, "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA=="],
@@ -828,35 +834,35 @@
 
     "@spaceduck/web": ["@spaceduck/web@workspace:apps/web"],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.2.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.0" } }, "sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.0", "@tailwindcss/oxide-darwin-arm64": "4.2.0", "@tailwindcss/oxide-darwin-x64": "4.2.0", "@tailwindcss/oxide-freebsd-x64": "4.2.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0", "@tailwindcss/oxide-linux-arm64-musl": "4.2.0", "@tailwindcss/oxide-linux-x64-gnu": "4.2.0", "@tailwindcss/oxide-linux-x64-musl": "4.2.0", "@tailwindcss/oxide-wasm32-wasi": "4.2.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.0", "@tailwindcss/oxide-win32-x64-msvc": "4.2.0" } }, "sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.0", "", { "os": "android", "cpu": "arm64" }, "sha512-F0QkHAVaW/JNBWl4CEKWdZ9PMb0khw5DCELAOnu+RtjAfx5Zgw+gqCHFvqg3AirU1IAd181fwOtJQ5I8Yx5wtw=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-I0QylkXsBsJMZ4nkUNSR04p6+UptjcwhcVo3Zu828ikiEqHjVmQL9RuQ6uT/cVIiKpvtVA25msu/eRV97JeNSA=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-6TmQIn4p09PBrmnkvbYQ0wbZhLtbaksCDx7Y7R3FYYx0yxNA7xg5KP7dowmQ3d2JVdabIHvs3Hx4K3d5uCf8xg=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-qBudxDvAa2QwGlq9y7VIzhTvp2mLJ6nD/G8/tI70DCDoneaUeLWBJaPcbfzqRIWraj+o969aDQKvKW9dvkUizw=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-7XKkitpy5NIjFZNUQPeUyNJNJn1CJeV7rmMR+exHfTuOsg8rxIO9eNV5TSEnqRcaOK77zQpsyUkBWmPy8FgdSg=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mff5a5Q3WoQR01pGU1gr29hHM1N93xYrKkGXfPw/aRtK4bOc331Ho4Tgfsm5WDGvpevqMpdlkCojT3qlCQbCpA=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.0", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.1", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2UU/15y1sWDEDNJXxEIrfWKC2Yb4YgIW5Xz2fKFqGzFWfoMHWFlfa1EJlGO2Xzjkq/tvSarh9ZTjvbxqWvLLXA=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-CrFadmFoc+z76EV6LPG1jx6XceDsaCG3lFhyLNo/bV9ByPrE+FnBPckXQVP4XRkN76h3Fjt/a+5Er/oA/nCBvQ=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
 
-    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.0", "", { "dependencies": { "@tailwindcss/node": "4.2.0", "@tailwindcss/oxide": "4.2.0", "tailwindcss": "4.2.0" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-da9mFCaHpoOgtQiWtDGIikTrSpUFBtIZCG3jy/u2BGV+l/X1/pbxzmIUxNt6JWm19N3WtGi4KlJdSH/Si83WOA=="],
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
 
@@ -1926,7 +1932,7 @@
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
-    "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
+    "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
@@ -2262,12 +2268,6 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "@spaceduck/ui/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
-
-    "@spaceduck/web/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
-
-    "@tailwindcss/node/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -2279,8 +2279,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
 
     "@whiskeysockets/baileys/@hapi/boom": ["@hapi/boom@9.1.4", "", { "dependencies": { "@hapi/hoek": "9.x.x" } }, "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw=="],
 
@@ -2305,8 +2303,6 @@
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "libsignal/protobufjs": ["protobufjs@6.8.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.0", "@types/node": "^10.1.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw=="],
 
@@ -2341,8 +2337,6 @@
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
-
-    "spaceduck-website/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -2470,8 +2464,6 @@
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
-    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
     "libsignal/protobufjs/@types/node": ["@types/node@10.17.60", "", {}, "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="],
 
     "libsignal/protobufjs/long": ["long@4.0.0", "", {}, "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="],
@@ -2595,8 +2587,6 @@
     "astro/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "astro/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,15 @@
     "test:memory": "bun test --recursive packages/memory/"
   },
   "devDependencies": {
-    "bun-plugin-tailwind": "latest",
-    "bun-types": "latest",
-    "tailwindcss": "^4",
+    "bun-plugin-tailwind": "^0.1.2",
+    "bun-types": "^1.3.9",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5"
+  },
+  "dependencies": {
+    "@tailwindcss/vite": "^4.2.1"
+  },
+  "overrides": {
+    "minimatch": "^10.2.2"
   }
 }

--- a/packages/channels/whatsapp/package.json
+++ b/packages/channels/whatsapp/package.json
@@ -10,11 +10,11 @@
   "dependencies": {
     "@hapi/boom": "^10",
     "@spaceduck/core": "workspace:*",
-    "@whiskeysockets/baileys": "latest",
+    "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "@types/qrcode-terminal": "^0.12",
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,7 +8,7 @@
     "zod": "^3.25.0"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "^1.3.9",
     "typescript": "^5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,6 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -25,7 +25,7 @@
     "@spaceduck/stt-whisper": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "^1.3.9",
     "json5": "^2.2.3"
   }
 }

--- a/packages/memory/sqlite/package.json
+++ b/packages/memory/sqlite/package.json
@@ -12,7 +12,7 @@
     "sqlite-vec": "^0.1.7-alpha.2"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "^1.3.9",
     "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2"
   }
 }

--- a/packages/providers/bedrock/package.json
+++ b/packages/providers/bedrock/package.json
@@ -11,6 +11,6 @@
     "@spaceduck/core": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/providers/gemini/package.json
+++ b/packages/providers/gemini/package.json
@@ -8,10 +8,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@spaceduck/core": "workspace:*",
-    "@google/genai": "latest"
+    "@google/genai": "^1.42.0",
+    "@spaceduck/core": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/providers/llamacpp/package.json
+++ b/packages/providers/llamacpp/package.json
@@ -12,6 +12,6 @@
     "@spaceduck/provider-openai-compat": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/providers/lmstudio/package.json
+++ b/packages/providers/lmstudio/package.json
@@ -12,6 +12,6 @@
     "@spaceduck/provider-openai-compat": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/providers/openai-compat/package.json
+++ b/packages/providers/openai-compat/package.json
@@ -11,6 +11,6 @@
     "@spaceduck/core": "workspace:*"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/providers/openrouter/package.json
+++ b/packages/providers/openrouter/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@spaceduck/core": "workspace:*",
-    "@openrouter/sdk": "latest"
+    "@openrouter/sdk": "^0.8.0"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/stt/whisper/package.json
+++ b/packages/stt/whisper/package.json
@@ -9,6 +9,6 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/tools/browser/package.json
+++ b/packages/tools/browser/package.json
@@ -9,9 +9,9 @@
     "test": "bun test"
   },
   "dependencies": {
-    "playwright": "latest"
+    "playwright": "^1.58.2"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/tools/marker/package.json
+++ b/packages/tools/marker/package.json
@@ -9,6 +9,6 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/tools/web-fetch/package.json
+++ b/packages/tools/web-fetch/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@types/html-to-text": "^9",
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/tools/web-search/package.json
+++ b/packages/tools/web-search/package.json
@@ -9,6 +9,6 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "bun-types": "^1.3.9"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,19 +24,19 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@spaceduck/core": "workspace:*",
-    "class-variance-authority": "latest",
-    "clsx": "latest",
-    "lucide-react": "latest",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.575.0",
     "react": "^19",
     "react-dom": "^19",
-    "react-markdown": "latest",
-    "tailwind-merge": "latest"
+    "react-markdown": "^10.1.0",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
-    "bun-types": "latest",
+    "bun-types": "^1.3.9",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "bun-plugin-tailwind": "latest"
+    "bun-plugin-tailwind": "^0.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Fix **HIGH** `minimatch` ReDoS vulnerability (GHSA-3ppc-4f35-3m26) via root override to `minimatch@^10.2.2`
- Update `tailwindcss` 4.1.18/4.2.0 -> 4.2.1 and `@tailwindcss/vite` 4.2.0 -> 4.2.1 across all workspaces
- Pin all 31 `"latest"` version specifiers to deterministic `^x.y.z` ranges across 20 `package.json` files for reproducible builds

## Test plan
- [x] `bun audit` — 0 vulnerabilities
- [x] `bun test` — 523 pass, 0 fail, 28 skip (live integration tests)
- [x] `bun outdated` — only Zod v4 major remains (deferred)

Made with [Cursor](https://cursor.com)