### PR TITLE
feat: cross-platform installer scripts, website install terminal, and docs restructure

### DIFF
--- a/apps/spaceduck-website/src/components/HeroButtons.tsx
+++ b/apps/spaceduck-website/src/components/HeroButtons.tsx
@@ -1,18 +1,8 @@
 import { Button } from "@/components/ui/button"
-import { BorderBeam } from "@/components/ui/border-beam"
 
 export function HeroButtons() {
   return (
     <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-      <Button asChild size="lg" className="relative overflow-hidden bg-primary text-white hover:bg-primary-dark">
-        <a href="https://docs.spaceduck.ai/quickstart" target="_blank" rel="noopener noreferrer">
-          Get Started
-          <svg className="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-          </svg>
-          <BorderBeam size={60} duration={4} colorFrom="#818cf8" colorTo="#6366f1" borderWidth={2} />
-        </a>
-      </Button>
       <Button asChild variant="outline" size="lg" className="border-white/15 bg-transparent text-slate-300 hover:border-white/30 hover:bg-white/5 hover:text-slate-200">
         <a href="https://github.com/maziarzamani/spaceduck" target="_blank" rel="noopener noreferrer">
           <svg className="mr-1 h-4 w-4" fill="currentColor" viewBox="0 0 24 24">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,7 +34,8 @@
         "group": "Start Here",
         "pages": [
           "index",
-          "quickstart"
+          "quickstart",
+          "install"
         ]
       },
       {

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -1,0 +1,95 @@
+---
+title: "Install"
+description: "Install Spaceduck using the one-line installer or from source."
+---
+
+## Installer
+
+The fastest way to get Spaceduck running. The installer handles Bun, system dependencies, and configuration automatically.
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://spaceduck.ai/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://spaceduck.ai/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+The installer will:
+
+1. Install [Bun](https://bun.sh) if not already present
+2. Clone the repository and install dependencies
+3. Set up SQLite with extension support
+4. Create a default `.env` file
+5. Start the gateway
+
+Once complete, open [http://localhost:3000](http://localhost:3000) and head to **Settings** to pick a provider.
+
+<Tip>
+  Want to inspect the script before running it?
+
+  ```bash
+  curl -fsSL https://spaceduck.ai/install.sh -o install.sh
+  less install.sh
+  bash install.sh
+  ```
+</Tip>
+
+## From source
+
+For contributors or if you prefer manual control.
+
+### Prerequisites
+
+- [Bun](https://bun.sh) v1.3 or later
+- A chat model — either a local server (llama.cpp, LM Studio) or a cloud API key (Bedrock, Gemini, OpenRouter)
+
+### Steps
+
+<Steps>
+  <Step title="Clone and install">
+    ```bash
+    git clone https://github.com/maziarzamani/spaceduck.git
+    cd spaceduck
+    bun install
+    ```
+  </Step>
+
+  <Step title="Install system dependencies">
+    <Tabs>
+      <Tab title="macOS">
+        ```bash
+        # SQLite with extension support (required for sqlite-vec)
+        brew install sqlite
+        ```
+      </Tab>
+      <Tab title="Linux">
+        SQLite with extension support is typically available by default. If you get sqlite-vec errors, install `libsqlite3-dev`.
+      </Tab>
+      <Tab title="Windows">
+        SQLite is bundled with Bun on Windows. No additional steps needed.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Configure deployment settings">
+    ```bash
+    cp .env.example .env
+    ```
+
+    The `.env` file controls deployment knobs only (port, log level). Provider settings are managed in the Settings UI.
+  </Step>
+
+  <Step title="Start the gateway">
+    ```bash
+    bun run dev
+    ```
+
+    Open [http://localhost:3000](http://localhost:3000) in your browser.
+  </Step>
+</Steps>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,78 +5,47 @@ description: "Get Spaceduck running and send your first message in under 5 minut
 
 After completing this guide, you'll have a running Spaceduck gateway with a chat model connected and ready to use.
 
-## Prerequisites
+## Install
 
-- [Bun](https://bun.sh) v1.3 or later
-- A chat model — either a local server (llama.cpp, LM Studio) or a cloud API key (Bedrock, Gemini, OpenRouter)
-
-## Install and run
-
-<Steps>
-  <Step title="Clone and install">
+<Tabs>
+  <Tab title="macOS / Linux">
     ```bash
-    git clone https://github.com/maziarzamani/spaceduck.git
-    cd spaceduck
-    bun install
+    curl -fsSL https://spaceduck.ai/install.sh | bash
     ```
-  </Step>
-
-  <Step title="Install system dependencies">
-    <Tabs>
-      <Tab title="macOS">
-        ```bash
-        # SQLite with extension support (required for sqlite-vec)
-        brew install sqlite
-        ```
-      </Tab>
-      <Tab title="Linux">
-        SQLite with extension support is typically available by default. If you get sqlite-vec errors, install `libsqlite3-dev`.
-      </Tab>
-      <Tab title="Windows">
-        SQLite is bundled with Bun on Windows. No additional steps needed.
-      </Tab>
-    </Tabs>
-  </Step>
-
-  <Step title="Configure deployment settings">
-    ```bash
-    cp .env.example .env
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://spaceduck.ai/install.ps1 | iex
     ```
+  </Tab>
+</Tabs>
 
-    The `.env` file controls deployment knobs only (port, log level). Provider settings are managed in the Settings UI.
-  </Step>
+<Info>
+  Prefer to install manually? See the [Install](/install) page for the from-source method.
+</Info>
 
-  <Step title="Start the gateway">
-    ```bash
-    bun run dev
-    ```
+## Configure your chat model
 
-    Open [http://localhost:3000](http://localhost:3000) in your browser.
-  </Step>
+Open [http://localhost:3000](http://localhost:3000) and click the **Settings** icon in the sidebar, then go to **Chat**.
 
-  <Step title="Configure your chat model">
-    Click the **Settings** icon in the sidebar, then go to **Chat**.
+1. Select a **Provider** from the dropdown (e.g., llama.cpp, Bedrock, Gemini)
+2. Enter the **Base URL** if using a local provider
+3. Set your **API key** if using a cloud provider
+4. Choose a **Model**
 
-    1. Select a **Provider** from the dropdown (e.g., llama.cpp, Bedrock, Gemini)
-    2. Enter the **Base URL** if using a local provider
-    3. Set your **API key** if using a cloud provider
-    4. Choose a **Model**
+Changes to provider, model, and system prompt hot-apply immediately — no restart needed.
 
-    Changes to provider, model, and system prompt hot-apply immediately — no restart needed.
+<Tip>
+  If you're unsure which provider to start with, see the [Model Providers overview](/providers/overview) for a comparison.
+</Tip>
 
-    <Tip>
-      If you're unsure which provider to start with, see the [Model Providers overview](/providers/overview) for a comparison.
-    </Tip>
-  </Step>
+## Send your first message
 
-  <Step title="Send your first message">
-    Go back to the chat view and type something. You should see a streaming response from your configured model.
+Go back to the chat view and type something. You should see a streaming response from your configured model.
 
-    <Check>
-      If you see a response, Spaceduck is working. Your conversations are now being stored in SQLite with automatic fact extraction.
-    </Check>
-  </Step>
-</Steps>
+<Check>
+  If you see a response, Spaceduck is working. Your conversations are now being stored in SQLite with automatic fact extraction.
+</Check>
 
 ## Optional: enable semantic recall
 


### PR DESCRIPTION
## Summary
- Add cross-platform installer scripts (`install.sh` for macOS/Linux, `install.ps1` for Windows) served from spaceduck.ai
- Replace the old "clone & install" terminal on the website with a tabbed install command component (shadcn Tabs) with copy-to-clipboard
- Remove "Get Started" button from hero — the installer terminal is now the primary CTA
- Move Quick Start section above Why Spaceduck for better flow
- Restructure docs: new `install.mdx` page with "Installer" and "From Source" sections, simplified `quickstart.mdx` using the one-liner as the primary path
- Various installer CI fixes (Windows delayed expansion, health checks)

## Test plan
- [x] Website builds cleanly (`bun run build`)
- [x] Tab switching and copy button work in the install terminal component
- [x] Installer CI workflow validates scripts on macOS, Linux, and Windows
- [x] Docs navigation updated with Install page

Made with [Cursor](https://cursor.com)