### PR TITLE
docs: split install into separate Installer and From Source pages

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,8 +34,14 @@
         "group": "Start Here",
         "pages": [
           "index",
-          "quickstart",
-          "install"
+          "quickstart"
+        ]
+      },
+      {
+        "group": "Install",
+        "pages": [
+          "install/installer",
+          "install/from-source"
         ]
       },
       {

--- a/docs/install/from-source.mdx
+++ b/docs/install/from-source.mdx
@@ -1,55 +1,16 @@
 ---
-title: "Install"
-description: "Install Spaceduck using the one-line installer or from source."
+title: "From Source"
+description: "Clone and build Spaceduck from source for development or manual control."
 ---
 
-## Installer
+For contributors or if you prefer manual control over the installation.
 
-The fastest way to get Spaceduck running. The installer handles Bun, system dependencies, and configuration automatically.
-
-<Tabs>
-  <Tab title="macOS / Linux">
-    ```bash
-    curl -fsSL https://spaceduck.ai/install.sh | bash
-    ```
-  </Tab>
-  <Tab title="Windows">
-    ```powershell
-    irm https://spaceduck.ai/install.ps1 | iex
-    ```
-  </Tab>
-</Tabs>
-
-The installer will:
-
-1. Install [Bun](https://bun.sh) if not already present
-2. Clone the repository and install dependencies
-3. Set up SQLite with extension support
-4. Create a default `.env` file
-5. Start the gateway
-
-Once complete, open [http://localhost:3000](http://localhost:3000) and head to **Settings** to pick a provider.
-
-<Tip>
-  Want to inspect the script before running it?
-
-  ```bash
-  curl -fsSL https://spaceduck.ai/install.sh -o install.sh
-  less install.sh
-  bash install.sh
-  ```
-</Tip>
-
-## From source
-
-For contributors or if you prefer manual control.
-
-### Prerequisites
+## Prerequisites
 
 - [Bun](https://bun.sh) v1.3 or later
 - A chat model — either a local server (llama.cpp, LM Studio) or a cloud API key (Bedrock, Gemini, OpenRouter)
 
-### Steps
+## Steps
 
 <Steps>
   <Step title="Clone and install">

--- a/docs/install/installer.mdx
+++ b/docs/install/installer.mdx
@@ -1,0 +1,39 @@
+---
+title: "Installer"
+description: "Install Spaceduck with a single command."
+---
+
+The fastest way to get Spaceduck running. The installer handles Bun, system dependencies, and configuration automatically.
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://spaceduck.ai/install.sh | bash
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    irm https://spaceduck.ai/install.ps1 | iex
+    ```
+  </Tab>
+</Tabs>
+
+The installer will:
+
+1. Install [Bun](https://bun.sh) if not already present
+2. Clone the repository and install dependencies
+3. Set up SQLite with extension support
+4. Create a default `.env` file
+5. Start the gateway
+
+Once complete, open [http://localhost:3000](http://localhost:3000) and head to **Settings** to pick a provider.
+
+<Tip>
+  Want to inspect the script before running it?
+
+  ```bash
+  curl -fsSL https://spaceduck.ai/install.sh -o install.sh
+  less install.sh
+  bash install.sh
+  ```
+</Tip>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -21,7 +21,7 @@ After completing this guide, you'll have a running Spaceduck gateway with a chat
 </Tabs>
 
 <Info>
-  Prefer to install manually? See the [Install](/install) page for the from-source method.
+  Prefer to install manually? See the [From Source](/install/from-source) guide.
 </Info>
 
 ## Configure your chat model


### PR DESCRIPTION
## Summary
- Split the single `install.mdx` into two pages under an **Install** nav section:
  - `install/installer.mdx` — one-liner script method
  - `install/from-source.mdx` — clone, build, configure manually
- Update docs.json navigation with the new Install group
- Fix quickstart.mdx link to point to the new from-source path

Made with [Cursor](https://cursor.com)