### PR TITLE
docs: update testing rule with fetch mock and message factory patterns

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -13,6 +13,12 @@ alwaysApply: false
 - Test files live in `src/__tests__/` adjacent to source code
 - Each test file: one `describe` block per function/class
 
+## Typecheck before pushing
+
+Bun runs tests without type-checking. CI runs `tsc --noEmit` as a separate
+step and will fail on type errors that tests happily pass at runtime.
+Always run `bun run typecheck` locally before pushing test changes.
+
 ## Pattern
 
 Follow Arrange-Act-Assert:
@@ -32,16 +38,71 @@ it("should do the thing", () => {
 
 ## Fixtures
 
-- Import shared fixtures from `@spaceduck/core` (re-exported from `__fixtures__/`)
+- Import shared fixtures directly from `@spaceduck/core/src/__fixtures__/`
 - `MockProvider` — configurable canned responses implementing `Provider`
 - `MockMemory` — in-memory Map-backed `ConversationStore` and `LongTermMemory`
 - `createMessage()`, `createConversation()` — factory functions with sensible defaults
+
+### Message factory
+
+`Message` requires `id` and `timestamp`. Never construct bare
+`{ role, content }` literals — use `createMessage()`:
+
+```typescript
+import { createMessage } from "@spaceduck/core/src/__fixtures__/messages";
+
+// Single message
+provider.chat([createMessage({ role: "user", content: "hi" })]);
+
+// System + user
+provider.chat([
+  createMessage({ role: "system", content: "Be helpful" }),
+  createMessage({ role: "user", content: "hello" }),
+]);
+
+// Tool round-trip
+provider.chat([
+  createMessage({ role: "user", content: "search for cats" }),
+  createMessage({
+    role: "assistant",
+    content: "",
+    toolCalls: [{ id: "tc1", name: "web_search", args: { query: "cats" } }],
+  }),
+  createMessage({ role: "tool", content: "10 results", toolCallId: "tc1", toolName: "web_search" }),
+]);
+```
+
+### Mocking `globalThis.fetch`
+
+Bun's `mock()` return type is missing the `preconnect` property that
+`typeof fetch` requires. Always cast with `as any`:
+
+```typescript
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// Correct — cast to any
+globalThis.fetch = mock(() =>
+  Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 })),
+) as any;
+
+// Also correct for capturing request details
+globalThis.fetch = mock((_url: string, init: RequestInit) => {
+  capturedBody = JSON.parse(init.body as string);
+  return Promise.resolve(new Response("{}"));
+}) as any;
+```
+
+`as any` on fetch mocks is the one accepted exception to the "no `any`" rule.
 
 ## Rules
 
 - NEVER test against real LLM providers — always use MockProvider
 - SQLite tests use `":memory:"` — new database per test via `beforeEach`
 - WebSocket tests pick a random available port
-- No `any` in tests — use proper typing
+- No `any` in tests — use proper typing (`as any` on fetch mocks is the sole exception)
 - Test behavior, not implementation — assert on outputs and side effects
 - Aim for 80% coverage, 100% on error paths


### PR DESCRIPTION
## Summary

- Adds guidance on running `bun run typecheck` locally before pushing (Bun test runner skips type-checking, but CI enforces it)
- Documents the `createMessage()` factory for constructing `Message` objects in tests (avoids missing `id`/`timestamp` errors)
- Documents the `as any` cast pattern for `globalThis.fetch = mock(...)` (Bun's `Mock` type lacks `preconnect`)
- Fixes the fixtures import path (they aren't re-exported from the barrel)

## Context

PR #76 introduced 189 new tests that passed locally but failed CI typecheck. These patterns are now documented so the same mistakes don't recur.

## Test plan

- [ ] No code changes — rule file only

Made with [Cursor](https://cursor.com)