### PR TITLE
feat: Docker container support with smoke test CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Dependencies / builds
+node_modules
+dist
+**/node_modules
+**/dist
+
+# VCS / CI
+.git
+.github
+
+# OS / editor
+.DS_Store
+Thumbs.db
+.vscode
+.idea
+
+# Env and secrets
+.env
+.env.*
+!.env.example
+
+# Desktop app / heavy local artifacts
+apps/desktop
+**/target
+**/*.rs.bk
+
+# Website and docs (not needed for gateway image)
+apps/spaceduck-website
+docs
+
+# Misc
+*.tgz
+*.log
+coverage
+tmp
+temp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,19 @@ jobs:
 
       - name: Run tests
         run: bun test --recursive
+
+  docker-smoke:
+    name: Docker Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.9"
+
+      - name: Run Docker smoke test
+        run: |
+          chmod +x scripts/smoke-docker.sh
+          scripts/smoke-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1.7
+
+############################
+# Stage 1: Build bundles
+############################
+FROM oven/bun:1.3.9 AS build
+
+WORKDIR /app
+
+# Copy manifests first for layer caching.
+# Bun workspaces require all package.json files for a frozen install.
+COPY package.json bun.lock ./
+COPY packages/config/package.json packages/config/package.json
+COPY packages/core/package.json packages/core/package.json
+COPY packages/gateway/package.json packages/gateway/package.json
+COPY packages/ui/package.json packages/ui/package.json
+COPY packages/channels/whatsapp/package.json packages/channels/whatsapp/package.json
+COPY packages/providers/gemini/package.json packages/providers/gemini/package.json
+COPY packages/providers/openrouter/package.json packages/providers/openrouter/package.json
+COPY packages/providers/bedrock/package.json packages/providers/bedrock/package.json
+COPY packages/providers/openai-compat/package.json packages/providers/openai-compat/package.json
+COPY packages/providers/llamacpp/package.json packages/providers/llamacpp/package.json
+COPY packages/providers/lmstudio/package.json packages/providers/lmstudio/package.json
+COPY packages/memory/sqlite/package.json packages/memory/sqlite/package.json
+COPY packages/tools/browser/package.json packages/tools/browser/package.json
+COPY packages/tools/web-fetch/package.json packages/tools/web-fetch/package.json
+COPY packages/tools/web-search/package.json packages/tools/web-search/package.json
+COPY packages/tools/marker/package.json packages/tools/marker/package.json
+COPY packages/stt/whisper/package.json packages/stt/whisper/package.json
+COPY apps/cli/package.json apps/cli/package.json
+COPY apps/desktop/package.json apps/desktop/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY apps/spaceduck-website/package.json apps/spaceduck-website/package.json
+
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+RUN bun run build
+RUN bun run build:cli
+
+
+############################
+# Stage 2: Runtime image
+############################
+FROM oven/bun:1.3.9-slim AS runtime
+
+ARG GIT_SHA=dev
+
+LABEL org.opencontainers.image.source="https://github.com/maziarzamani/spaceduck"
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+
+WORKDIR /app
+
+# Install sqlite-vec native addon in an isolated directory so we don't mutate
+# the app package.json. The addon must match the runtime OS/arch.
+WORKDIR /runtime-deps
+RUN bun init -y >/dev/null 2>&1 \
+  && bun add sqlite-vec@0.1.7-alpha.2
+
+WORKDIR /app
+
+COPY --from=build /app/dist/index.js /app/spaceduck-gateway.js
+COPY --from=build /app/dist/cli/index.js /app/spaceduck-cli.js
+COPY --from=runtime /runtime-deps/node_modules /app/node_modules
+
+RUN mkdir -p /data
+
+ENV PORT=3000
+ENV MEMORY_CONNECTION_STRING=/data/spaceduck.db
+ENV NODE_ENV=production
+ENV GIT_SHA=${GIT_SHA}
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=20s --retries=5 \
+  CMD bun -e "fetch('http://127.0.0.1:' + (process.env.PORT || '3000') + '/api/health').then(r => { if (!r.ok) throw new Error('bad status ' + r.status); }).catch(() => process.exit(1))"
+
+CMD ["bun", "run", "/app/spaceduck-gateway.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  spaceduck:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        GIT_SHA: "${GIT_SHA:-dev}"
+    container_name: spaceduck
+    ports:
+      - "3000:3000"
+    volumes:
+      - spaceduck-data:/data
+    environment:
+      PORT: "3000"
+      MEMORY_CONNECTION_STRING: "/data/spaceduck.db"
+
+      LOG_LEVEL: "info"
+
+      # Provider is configured via the Settings UI or `spaceduck setup`.
+      # To override via env vars instead, uncomment one of the blocks below.
+
+      # Cloud provider:
+      # PROVIDER_NAME: "gemini"
+      # GEMINI_API_KEY: "${GEMINI_API_KEY}"
+
+      # PROVIDER_NAME: "openrouter"
+      # OPENROUTER_API_KEY: "${OPENROUTER_API_KEY}"
+
+      # PROVIDER_NAME: "bedrock"
+      # AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
+      # AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
+      # AWS_REGION: "${AWS_REGION}"
+
+      # Local model server on the host machine:
+      # PROVIDER_NAME: "llamacpp"
+      # PROVIDER_BASE_URL: "http://host.docker.internal:8080/v1"   # macOS/Windows
+      # On Linux, use --network=host or your host IP (see docs)
+    restart: unless-stopped
+
+volumes:
+  spaceduck-data:
+    driver: local

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,8 @@
         "group": "Install",
         "pages": [
           "install/installer",
-          "install/from-source"
+          "install/from-source",
+          "install/docker"
         ]
       },
       {

--- a/docs/install/docker.mdx
+++ b/docs/install/docker.mdx
@@ -1,0 +1,145 @@
+---
+title: "Docker"
+description: "Run Spaceduck in Docker with persistent storage using a single container for the gateway and CLI."
+---
+
+The Docker image packages the gateway and CLI into a single container using Bun as the runtime.
+
+## Quick start
+
+<Steps>
+  <Step title="Build the image">
+    ```bash
+    docker build -t spaceduck .
+    ```
+  </Step>
+
+  <Step title="Run the container">
+    ```bash
+    docker run -d \
+      -p 3000:3000 \
+      -v spaceduck-data:/data \
+      spaceduck
+    ```
+
+    Open [http://localhost:3000](http://localhost:3000) to launch the Settings UI and configure your AI provider.
+  </Step>
+</Steps>
+
+## Docker Compose
+
+A `docker-compose.yml` is included for the common case.
+
+```bash
+# Start
+docker compose up --build -d
+
+# View logs
+docker compose logs -f
+
+# Stop
+docker compose down
+```
+
+Data persists in the `spaceduck-data` volume across restarts and upgrades.
+
+## Persistence
+
+The container stores its SQLite database at `/data/spaceduck.db`. The compose file mounts a named volume at `/data`, so your data survives container restarts.
+
+Default database path inside the container:
+
+```
+/data/spaceduck.db
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PORT` | `3000` | Gateway listen port |
+| `LOG_LEVEL` | `info` | Logging verbosity (`debug`, `info`, `warn`, `error`) |
+| `PROVIDER_NAME` | *(unset)* | AI provider (configured via Settings UI or env) |
+| `PROVIDER_MODEL` | *(unset)* | Optional model override |
+| `MEMORY_BACKEND` | `sqlite` | Memory backend |
+| `MEMORY_CONNECTION_STRING` | `spaceduck.db` | SQLite file path (set to `/data/spaceduck.db` in Docker) |
+
+### API keys
+
+Pass provider API keys as environment variables:
+
+- `GEMINI_API_KEY`
+- `OPENROUTER_API_KEY`
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`
+
+<Tip>
+  Use a local `.env` file with Docker Compose and keep it out of version control.
+</Tip>
+
+## Running the CLI inside the container
+
+The image includes the CLI bundle. If your container is named `spaceduck`:
+
+```bash
+docker exec -it spaceduck bun /app/spaceduck-cli.js status
+docker exec -it spaceduck bun /app/spaceduck-cli.js version
+docker exec -it spaceduck bun /app/spaceduck-cli.js config paths
+```
+
+## Local AI providers
+
+If you want Spaceduck inside Docker to connect to a model server running on your host machine (LM Studio, llama.cpp, etc.):
+
+<Tabs>
+  <Tab title="macOS / Windows">
+    Docker Desktop provides `host.docker.internal` to reach the host:
+
+    ```bash
+    docker run -d \
+      -p 3000:3000 \
+      -v spaceduck-data:/data \
+      -e PROVIDER_NAME=llamacpp \
+      -e PROVIDER_BASE_URL=http://host.docker.internal:8080/v1 \
+      spaceduck
+    ```
+  </Tab>
+  <Tab title="Linux">
+    `host.docker.internal` may not exist by default. Options:
+
+    **Host networking** (simplest for local dev):
+    ```bash
+    docker run -d \
+      --network=host \
+      -v spaceduck-data:/data \
+      -e PORT=3000 \
+      -e PROVIDER_NAME=llamacpp \
+      -e PROVIDER_BASE_URL=http://127.0.0.1:8080/v1 \
+      spaceduck
+    ```
+
+    **Explicit host mapping:**
+    ```bash
+    docker run -d \
+      --add-host=host.docker.internal:host-gateway \
+      -p 3000:3000 \
+      -v spaceduck-data:/data \
+      -e PROVIDER_NAME=llamacpp \
+      -e PROVIDER_BASE_URL=http://host.docker.internal:8080/v1 \
+      spaceduck
+    ```
+  </Tab>
+</Tabs>
+
+## Healthcheck
+
+The image includes a built-in healthcheck against `/api/health`. Verify manually:
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+## Notes
+
+- **Playwright/browser tooling** is not included in the default image to keep it lean.
+- The Docker image is intended for gateway-first usage. The CLI is included for setup and maintenance inside the container.
+- To add custom binaries or system packages, extend the image with your own Dockerfile.

--- a/scripts/smoke-docker.sh
+++ b/scripts/smoke-docker.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker smoke test for spaceduck.
+# Runnable locally:  ./scripts/smoke-docker.sh
+# Called by CI:      scripts/smoke-docker.sh
+
+IMAGE_TAG="spaceduck-smoke:$(date +%s)-$$"
+CID=""
+VOL="spaceduck-smoke-$$"
+
+cleanup() {
+  code=$?
+  if [ $code -ne 0 ] && [ -n "${CID:-}" ]; then
+    echo ""
+    echo "=== Container logs (failure) ==="
+    docker logs "$CID" 2>&1 || true
+  fi
+  [ -n "${CID:-}" ] && docker rm -f "$CID" >/dev/null 2>&1 || true
+  docker volume rm "$VOL" >/dev/null 2>&1 || true
+  if [ $code -eq 0 ]; then
+    echo ""
+    echo "Smoke test passed."
+  else
+    echo ""
+    echo "Smoke test FAILED (exit $code)."
+  fi
+  exit $code
+}
+trap cleanup EXIT
+
+echo "=== Building image: $IMAGE_TAG ==="
+docker build --pull -t "$IMAGE_TAG" .
+
+echo ""
+echo "=== Starting container ==="
+CID=$(docker run -d \
+  --name "spaceduck-smoke-$$" \
+  -v "$VOL":/data \
+  -e MEMORY_CONNECTION_STRING=/data/spaceduck.db \
+  "$IMAGE_TAG")
+echo "Container: $CID"
+
+echo ""
+echo "=== Waiting for /api/health ==="
+PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "3000/tcp") 0).HostPort}}' "$CID" 2>/dev/null || echo "")
+if [ -z "$PORT" ]; then
+  # No port mapping; exec inside container instead
+  HEALTH_CMD='bun -e "const r=await fetch(\"http://127.0.0.1:3000/api/health\");if(!r.ok)throw 1;console.log(await r.text())"'
+  for i in $(seq 1 30); do
+    if docker exec "$CID" sh -c "$HEALTH_CMD" >/dev/null 2>&1; then
+      echo "  Health OK after ${i}s"
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      echo "  Timed out waiting for health"
+      exit 1
+    fi
+    sleep 1
+  done
+else
+  for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1; then
+      echo "  Health OK after ${i}s"
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      echo "  Timed out waiting for health"
+      exit 1
+    fi
+    sleep 1
+  done
+fi
+
+echo ""
+echo "=== Asserting /api/health response fields ==="
+HEALTH_JSON=$(docker exec "$CID" bun -e "const r=await fetch('http://127.0.0.1:3000/api/health');console.log(await r.text())")
+echo "  $HEALTH_JSON"
+
+echo "$HEALTH_JSON" | bun -e "
+  const h = JSON.parse(await new Response(Bun.stdin.stream()).text());
+  const assert = (cond, msg) => { if (!cond) { console.error('FAIL: ' + msg); process.exit(1); } };
+  assert(h.status === 'ok', 'status should be ok');
+  assert(typeof h.version === 'string', 'version should be a string');
+  assert(typeof h.apiVersion === 'number', 'apiVersion should be a number');
+  assert(typeof h.commit === 'string', 'commit should be a string');
+  console.log('  version=' + h.version + ' apiVersion=' + h.apiVersion + ' commit=' + h.commit);
+"
+
+echo ""
+echo "=== CLI smoke: --help ==="
+docker exec "$CID" bun /app/spaceduck-cli.js --help
+echo "  CLI --help OK"
+
+echo ""
+echo "=== Sentinel persistence test ==="
+docker exec "$CID" sh -c 'echo quack > /data/.smoke'
+echo "  Wrote sentinel file"
+
+echo ""
+echo "=== Restarting container ==="
+docker restart "$CID"
+
+echo "  Waiting for health after restart..."
+for i in $(seq 1 30); do
+  if docker exec "$CID" sh -c "$HEALTH_CMD" >/dev/null 2>&1; then
+    echo "  Health OK after restart (${i}s)"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "  Timed out after restart"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo ""
+echo "=== Verifying sentinel file survived restart ==="
+SENTINEL=$(docker exec "$CID" sh -c 'cat /data/.smoke')
+if [ "$SENTINEL" = "quack" ]; then
+  echo "  Sentinel OK: $SENTINEL"
+else
+  echo "  FAIL: expected 'quack', got '$SENTINEL'"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Depends on #79.

- Add multi-stage `Dockerfile` pinned to `oven/bun:1.3.9` with OCI labels and `GIT_SHA` build arg
- Install `sqlite-vec` native addon in isolated `/runtime-deps` directory (no app `package.json` mutation)
- Add `docker-compose.yml` with volume persistence; no healthcheck duplication (relies on Dockerfile `HEALTHCHECK`)
- Provider-agnostic: no hardcoded provider default, relies on Settings UI / `spaceduck setup` onboarding
- Add `docs/install/docker.mdx` covering quick start, compose, env vars, persistence, CLI usage, local provider networking
- Add `scripts/smoke-docker.sh`: health field assertions (`version`, `apiVersion`, `commit`), CLI `--help` smoke, sentinel file persistence through restart, `trap cleanup EXIT`
- Add `docker-smoke` CI job to `.github/workflows/ci.yml`

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test --recursive` passes (832 tests, 0 failures)
- [ ] `docker build -t spaceduck .` succeeds
- [ ] `docker run` starts and `/api/health` returns 200 with version fields
- [ ] `docker exec spaceduck bun /app/spaceduck-cli.js --help` works
- [ ] Data in `/data` persists across `docker restart`
- [ ] `./scripts/smoke-docker.sh` passes end-to-end locally


Made with [Cursor](https://cursor.com)