### PR TITLE
docs: refresh README with install methods, Docker, and updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 </p>
 
 <p align="center">
+  <a href="https://spaceduck.ai">Website</a> ·
   <a href="https://docs.spaceduck.ai">Docs</a> ·
   <a href="https://github.com/maziarzamani/spaceduck/issues">Issues</a> ·
   <a href="https://github.com/maziarzamani/spaceduck/discussions">Discussions</a>
@@ -34,7 +35,29 @@ No agent frameworks, no orchestration wrappers — every layer is handwritten Ty
   <img src="assets/desktop-app-screen.png" alt="Spaceduck Desktop App" width="720">
 </p>
 
-## Quickstart
+## Install
+
+### Installer (recommended)
+
+```bash
+curl -fsSL https://spaceduck.ai/install.sh | bash
+```
+
+On Windows: `irm https://spaceduck.ai/install.ps1 | iex`
+
+> Full installer docs: [Docs → Installer](https://docs.spaceduck.ai/install/installer)
+
+### Docker
+
+```bash
+docker compose up --build -d
+```
+
+Data persists in the `spaceduck-data` volume across restarts and upgrades.
+
+> Full Docker guide: [Docs → Docker](https://docs.spaceduck.ai/install/docker)
+
+### From source
 
 ```bash
 git clone https://github.com/maziarzamani/spaceduck.git
@@ -43,26 +66,28 @@ bun install
 bun run dev
 ```
 
+> Full source build guide: [Docs → From Source](https://docs.spaceduck.ai/install/from-source)
+
+---
+
 Open [http://localhost:3000](http://localhost:3000) → **Settings** → pick a chat model provider → start chatting.
 
 **Optional:** enable semantic memory recall in **Settings > Memory** by toggling on Semantic recall and configuring an embedding model.
-
-> Full setup guide with platform-specific steps: [Docs → Quickstart](https://spaceduck.mintlify.app/quickstart)
 
 ## Model Providers
 
 Spaceduck supports both local and cloud providers. Chat and embeddings are independent — mix and match.
 
 **Local**
-- [llama.cpp](https://spaceduck.mintlify.app/providers/llamacpp) — llama-server, full control, any GGUF model
-- [LM Studio](https://spaceduck.mintlify.app/providers/lmstudio) — GUI-based, built-in model browser
+- [llama.cpp](https://docs.spaceduck.ai/providers/llamacpp) — llama-server, full control, any GGUF model
+- [LM Studio](https://docs.spaceduck.ai/providers/lmstudio) — GUI-based, built-in model browser
 
 **Cloud**
-- [AWS Bedrock](https://spaceduck.mintlify.app/providers/bedrock) — Nova, Claude, Titan embeddings
-- [Google Gemini](https://spaceduck.mintlify.app/providers/gemini) — chat + embeddings, generous free tier
-- [OpenRouter](https://spaceduck.mintlify.app/providers/openrouter) — hundreds of models, one API key
+- [AWS Bedrock](https://docs.spaceduck.ai/providers/bedrock) — Nova, Claude, Titan embeddings
+- [Google Gemini](https://docs.spaceduck.ai/providers/gemini) — chat + embeddings, generous free tier
+- [OpenRouter](https://docs.spaceduck.ai/providers/openrouter) — hundreds of models, one API key
 
-> Provider setup guides: [Docs → Model Providers](https://spaceduck.mintlify.app/providers/overview)
+> Provider setup guides: [Docs → Model Providers](https://docs.spaceduck.ai/providers/overview)
 
 ## Why Spaceduck
 
@@ -75,7 +100,7 @@ Spaceduck supports both local and cloud providers. Chat and embeddings are indep
 - **Two-server pattern** — run chat and embeddings on separate endpoints (local, cloud, or mixed)
 - **Zero dependencies** — no LangChain, no LlamaIndex, no hidden abstractions
 
-> Deep dive: [Docs → Memory Search](https://spaceduck.mintlify.app/concepts/memory-search)
+> Deep dive: [Docs → Memory Search](https://docs.spaceduck.ai/concepts/memory-search)
 
 ## Platforms
 
@@ -85,8 +110,9 @@ Spaceduck supports both local and cloud providers. Chat and embeddings are indep
 | **Web UI** | React chat with streaming, settings, file upload, voice dictation |
 | **Desktop** | Tauri v2 native app with gateway sidecar (macOS, Linux, Windows) |
 | **CLI** | `spaceduck status`, `config get/set`, `secret set/unset` |
+| **WhatsApp** | Messaging via QR-code pairing (Baileys) |
 
-> Details: [Docs → Platforms](https://spaceduck.mintlify.app/platforms/gateway)
+> Details: [Docs → Platforms](https://docs.spaceduck.ai/platforms/gateway)
 
 ## Tools
 
@@ -98,21 +124,33 @@ Spaceduck supports both local and cloud providers. Chat and embeddings are indep
 | **Document Scan** | PDF-to-markdown via [Marker](https://github.com/VikParuchuri/marker) |
 | **Voice Input** | Speech-to-text via [Whisper](https://github.com/openai/whisper) |
 
-> Setup guides: [Docs → Tools](https://spaceduck.mintlify.app/tools/overview)
+> Setup guides: [Docs → Tools](https://docs.spaceduck.ai/tools/overview)
 
 ## Development
 
+Spaceduck is a Bun monorepo. Core logic lives in `packages/` (core, gateway, config, providers, memory, tools, channels) and applications live in `apps/` (web, desktop, CLI, website).
+
 ```bash
-bun test --recursive     # Run all tests
-bun run dev              # Dev server with hot reload
-bun run dev:desktop      # Desktop app + gateway
+bun install                # Install all workspace dependencies
+bun run dev                # Dev server with hot reload
+bun run dev:desktop        # Desktop app + gateway
 ```
 
-> Test suites, project structure, and contributing guidelines: [Docs → Reference](https://spaceduck.mintlify.app/reference/common-errors)
+### Testing
+
+```bash
+bun test --recursive       # All tests
+bun run test:unit          # Core unit tests
+bun run test:e2e           # End-to-end gateway tests
+bun run test:coverage      # Coverage report
+bash scripts/smoke-docker.sh  # Docker build + smoke test
+```
+
+> Test suites, project structure, and contributing guidelines: [Docs → Reference](https://docs.spaceduck.ai/reference/common-errors)
 
 ## Roadmap
 
-Tracked in the [docs](https://spaceduck.mintlify.app) and [GitHub Issues](https://github.com/maziarzamani/spaceduck/issues). Top priorities:
+Tracked in [GitHub Issues](https://github.com/maziarzamani/spaceduck/issues). Top priorities:
 
 1. **Per-user isolation** — scope memory by user identity across channels
 2. **Provider fallback chain** — auto-retry with a secondary provider


### PR DESCRIPTION
## Summary

- Add three install paths to the README: one-line installer (recommended), Docker, and from-source — replacing the single from-source Quickstart
- Standardize all documentation links from `spaceduck.mintlify.app` to `docs.spaceduck.ai` and add `spaceduck.ai` website link to the top nav
- Add WhatsApp to the Platforms table, expand the Development section with monorepo overview and full test commands, and clean up the Roadmap link

## Test plan

- [ ] Verify all `docs.spaceduck.ai` links resolve (providers, install, concepts, tools, platforms, reference)
- [ ] Confirm `spaceduck.ai` website link works
- [ ] Check README renders correctly on GitHub (images, tables, badges, blockquotes)

Made with [Cursor](https://cursor.com)