### PR TITLE
fix: use OS-assigned ports in gateway tests to eliminate flaky port c…

### DIFF
--- a/packages/gateway/src/__tests__/e2e.test.ts
+++ b/packages/gateway/src/__tests__/e2e.test.ts
@@ -29,7 +29,6 @@ async function createTestGateway(port: number): Promise<Gateway> {
 
 describe("Gateway E2E smoke", () => {
   let gateway: Gateway;
-  const PORT = 49152 + Math.floor(Math.random() * 10000);
 
   afterEach(async () => {
     if (gateway?.status === "running") {
@@ -38,8 +37,9 @@ describe("Gateway E2E smoke", () => {
   });
 
   it("should start and respond to health check", async () => {
-    gateway = await createTestGateway(PORT);
+    gateway = await createTestGateway(0);
     await gateway.start();
+    const PORT = gateway.port;
 
     expect(gateway.status).toBe("running");
 
@@ -59,16 +59,18 @@ describe("Gateway E2E smoke", () => {
   });
 
   it("should return 404 for unknown routes", async () => {
-    gateway = await createTestGateway(PORT);
+    gateway = await createTestGateway(0);
     await gateway.start();
+    const PORT = gateway.port;
 
     const res = await fetch(`http://localhost:${PORT}/api/nope`);
     expect(res.status).toBe(404);
   });
 
   it("should list conversations (initially empty)", async () => {
-    gateway = await createTestGateway(PORT);
+    gateway = await createTestGateway(0);
     await gateway.start();
+    const PORT = gateway.port;
 
     const res = await fetch(`http://localhost:${PORT}/api/conversations`);
     expect(res.status).toBe(200);
@@ -78,8 +80,9 @@ describe("Gateway E2E smoke", () => {
   });
 
   it("should run agent loop and persist messages", async () => {
-    gateway = await createTestGateway(PORT);
+    gateway = await createTestGateway(0);
     await gateway.start();
+    const PORT = gateway.port;
 
     const { agent, conversationStore, sessionManager } = gateway.deps;
 
@@ -120,7 +123,7 @@ describe("Gateway E2E smoke", () => {
   });
 
   it("should be idempotent on start/stop", async () => {
-    gateway = await createTestGateway(PORT);
+    gateway = await createTestGateway(0);
 
     await gateway.start();
     await gateway.start(); // no-op

--- a/packages/gateway/src/__tests__/embedding-status.test.ts
+++ b/packages/gateway/src/__tests__/embedding-status.test.ts
@@ -45,7 +45,7 @@ function baseConfig(port: number) {
   };
 }
 
-const BASE_PORT = 49800 + Math.floor(Math.random() * 1000);
+const TEST_PORT = 0;
 
 describe("GET /api/config/embedding-status", () => {
   let gateway: Gateway;
@@ -55,13 +55,12 @@ describe("GET /api/config/embedding-status", () => {
   });
 
   it("returns ok:false when no embedding provider is configured", async () => {
-    const port = BASE_PORT;
     gateway = await createGateway({
       provider: new StubProvider(),
-      config: baseConfig(port),
-      // no embeddingProvider
+      config: baseConfig(TEST_PORT),
     });
     await gateway.start();
+    const port = gateway.port;
 
     const res = await fetch(`http://localhost:${port}/api/config/embedding-status`);
     expect(res.status).toBe(200);
@@ -72,13 +71,13 @@ describe("GET /api/config/embedding-status", () => {
   });
 
   it("returns ok:true when embedding provider responds successfully", async () => {
-    const port = BASE_PORT + 1;
     gateway = await createGateway({
       provider: new StubProvider(),
-      config: baseConfig(port),
+      config: baseConfig(TEST_PORT),
       embeddingProvider: new OkEmbeddingProvider(),
     });
     await gateway.start();
+    const port = gateway.port;
 
     const res = await fetch(`http://localhost:${port}/api/config/embedding-status`);
     expect(res.status).toBe(200);
@@ -90,13 +89,13 @@ describe("GET /api/config/embedding-status", () => {
   });
 
   it("returns ok:false with error message when embedding provider throws", async () => {
-    const port = BASE_PORT + 2;
     gateway = await createGateway({
       provider: new StubProvider(),
-      config: baseConfig(port),
+      config: baseConfig(TEST_PORT),
       embeddingProvider: new FailingEmbeddingProvider(),
     });
     await gateway.start();
+    const port = gateway.port;
 
     const res = await fetch(`http://localhost:${port}/api/config/embedding-status`);
     expect(res.status).toBe(200);
@@ -109,14 +108,14 @@ describe("GET /api/config/embedding-status", () => {
   it("returns 401 when auth is required and no token is provided", async () => {
     const origAuth = process.env.SPACEDUCK_REQUIRE_AUTH;
     process.env.SPACEDUCK_REQUIRE_AUTH = "1";
-    const port = BASE_PORT + 3;
     try {
       gateway = await createGateway({
         provider: new StubProvider(),
-        config: baseConfig(port),
+        config: baseConfig(TEST_PORT),
         embeddingProvider: new OkEmbeddingProvider(),
       });
       await gateway.start();
+      const port = gateway.port;
 
       const res = await fetch(`http://localhost:${port}/api/config/embedding-status`);
       expect(res.status).toBe(401);

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -158,6 +158,10 @@ export class Gateway implements Lifecycle {
     return this._status;
   }
 
+  get port(): number {
+    return this.server?.port ?? 0;
+  }
+
   async start(): Promise<void> {
     if (this._status === "running" || this._status === "starting") return;
     this._status = "starting";


### PR DESCRIPTION
…ollisions

Add a `port` getter to Gateway that exposes the actual listening port from Bun.serve. All test files now pass port 0 (OS-assigned) and read gateway.port after start, removing the overlapping random-range scheme that caused "port in use" failures in CI.

## Summary

<!--
2-5 bullets: what problem this solves, what changed, what did NOT change.
-->

-
-

## Change type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling
- [ ] Breaking change

## Linked issue

<!-- Closes #NNN  or  N/A -->

## Testing

<!-- How did you verify this works? What did you test? What did you NOT test? -->

- [ ] `bun test --recursive` passes
- [ ] `bun run typecheck` is clean
- [ ] `bun run build` succeeds
- [ ] Tested manually (describe below)

## Security impact

<!-- Does this change touch auth, credentials, network, file I/O, or LLM prompt construction? -->

- [ ] No security impact
- [ ] Yes — explain:

## AI-assisted

- [ ] This PR was fully or partly written with AI assistance (Cursor / Claude / Codex / other)
