### PR TITLE
feat: config input validation

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,4 @@
-export { SpaceduckConfigSchema } from "./schema";
+export { SpaceduckConfigSchema, HttpUrlSchema, SttModelEnum } from "./schema";
 export { DEFAULT_SYSTEM_PROMPT } from "./constants";
 export type { SpaceduckProductConfig } from "./types";
 export type { ConfigPatchOp } from "./types";

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -2,6 +2,19 @@ import { z } from "zod";
 import { hostname } from "node:os";
 import { DEFAULT_SYSTEM_PROMPT } from "./constants";
 
+export const HttpUrlSchema = z
+  .string()
+  .refine((value) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, "Invalid URL (expected http:// or https://)");
+
+export const SttModelEnum = z.enum(["tiny", "base", "small", "medium", "large"]);
+
 const AiProviderEnum = z.enum(["gemini", "bedrock", "openrouter", "lmstudio", "llamacpp"]);
 
 const AiSecretsSchema = z.object({
@@ -15,7 +28,7 @@ const AiSecretsSchema = z.object({
 const AiSchema = z.object({
   provider: AiProviderEnum.default("gemini"),
   model: z.string().nullable().default("gemini-2.5-flash"),
-  baseUrl: z.string().nullable().default(null),
+  baseUrl: HttpUrlSchema.nullable().default(null),
   temperature: z.number().min(0).max(2).default(0.7),
   systemPrompt: z.string().nullable().default(DEFAULT_SYSTEM_PROMPT),
   region: z.string().nullable().default(null),
@@ -37,13 +50,13 @@ const EmbeddingSchema = z.object({
   enabled: z.boolean().default(true),
   provider: EmbeddingProviderEnum.nullable().default(null),
   model: z.string().nullable().default(null),
-  baseUrl: z.string().nullable().default(null),
+  baseUrl: HttpUrlSchema.nullable().default(null),
   dimensions: z.number().int().positive().nullable().default(null),
 });
 
 const SttSchema = z.object({
   enabled: z.boolean().default(true),
-  model: z.string().default("small"),
+  model: SttModelEnum.default("small"),
   languageHint: z.string().nullable().default(null),
 });
 
@@ -55,7 +68,7 @@ const WebSearchProviderEnum = z.enum(["brave", "searxng"]);
 
 const WebSearchSchema = z.object({
   provider: WebSearchProviderEnum.nullable().default(null),
-  searxngUrl: z.string().nullable().default(null),
+  searxngUrl: HttpUrlSchema.nullable().default(null),
   secrets: WebSearchSecretsSchema.default({}),
 });
 

--- a/packages/ui/src/components/settings/shared.ts
+++ b/packages/ui/src/components/settings/shared.ts
@@ -24,3 +24,20 @@ export function isSecretSet(
 ): boolean {
   return secrets.find((s) => s.path === path)?.isSet ?? false;
 }
+
+/** Validate and normalize an HTTP(S) URL. UI owns normalization (trim + strip trailing slash). */
+export function validateHttpUrl(
+  value: string,
+): { ok: true; normalized: string } | { ok: false; message: string } {
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: true, normalized: "" };
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return { ok: false, message: "URL must start with http:// or https://" };
+    }
+    return { ok: true, normalized: trimmed.replace(/\/+$/, "") };
+  } catch {
+    return { ok: false, message: "Enter a valid URL (e.g. http://localhost:8080)" };
+  }
+}

--- a/packages/ui/src/components/settings/speech-section.tsx
+++ b/packages/ui/src/components/settings/speech-section.tsx
@@ -1,38 +1,11 @@
-import { useState, useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "../../ui/card";
 import { Label } from "../../ui/label";
-import { Input } from "../../ui/input";
 import { Switch } from "../../ui/switch";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "../../ui/select";
+import { DebouncedInput } from "../shared/debounced-input";
 import type { SectionProps } from "./shared";
 import { getPath } from "./shared";
-
-function DebouncedInput({
-  value: externalValue,
-  onCommit,
-  ...props
-}: Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> & {
-  value: string;
-  onCommit: (value: string) => void;
-}) {
-  const [local, setLocal] = useState(externalValue);
-  useEffect(() => setLocal(externalValue), [externalValue]);
-
-  return (
-    <Input
-      {...props}
-      value={local}
-      onChange={(e) => setLocal(e.target.value)}
-      onBlur={() => {
-        if (local !== externalValue) onCommit(local);
-      }}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          (e.target as HTMLInputElement).blur();
-        }
-      }}
-    />
-  );
-}
 
 export function SpeechSection({ cfg }: SectionProps) {
   const config = cfg.config;
@@ -86,12 +59,21 @@ export function SpeechSection({ cfg }: SectionProps) {
           <CardContent className="pt-6 flex flex-col gap-4">
             <div className="grid gap-2">
               <Label htmlFor="stt-model">Whisper Model</Label>
-              <DebouncedInput
-                id="stt-model"
+              <Select
                 value={model}
-                placeholder="tiny, base, small, medium, large"
-                onCommit={(v) => patch("/stt/model", v || "small")}
-              />
+                onValueChange={(v) => patch("/stt/model", v)}
+              >
+                <SelectTrigger id="stt-model">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="tiny">tiny</SelectItem>
+                  <SelectItem value="base">base</SelectItem>
+                  <SelectItem value="small">small</SelectItem>
+                  <SelectItem value="medium">medium</SelectItem>
+                  <SelectItem value="large">large</SelectItem>
+                </SelectContent>
+              </Select>
               <p className="text-xs text-muted-foreground">
                 Larger models are more accurate but slower. "small" is a good balance.
               </p>
@@ -103,7 +85,10 @@ export function SpeechSection({ cfg }: SectionProps) {
                 id="stt-lang"
                 value={languageHint}
                 placeholder="e.g. en, da, de (auto-detect if empty)"
-                onCommit={(v) => patch("/stt/languageHint", v || null)}
+                onCommit={async (v) => {
+                  patch("/stt/languageHint", v || null);
+                  return true;
+                }}
               />
               <p className="text-xs text-muted-foreground">
                 ISO 639-1 code. Leave empty for auto-detection.

--- a/packages/ui/src/components/shared/debounced-input.tsx
+++ b/packages/ui/src/components/shared/debounced-input.tsx
@@ -29,10 +29,14 @@ export { useSaveFlash };
 export function DebouncedInput({
   value: externalValue,
   onCommit,
+  error,
+  onLocalChange,
   ...props
 }: Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> & {
   value: string;
   onCommit: (value: string) => Promise<boolean>;
+  error?: string | null;
+  onLocalChange?: (value: string) => void;
 }) {
   const [local, setLocal] = useState(externalValue);
   const { saved, flash } = useSaveFlash();
@@ -46,18 +50,24 @@ export function DebouncedInput({
   };
 
   return (
-    <div className="flex items-center gap-2">
-      <Input
-        {...props}
-        value={local}
-        onChange={(e) => setLocal(e.target.value)}
-        onBlur={commit}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") (e.target as HTMLInputElement).blur();
-        }}
-        className={`flex-1 ${props.className ?? ""}`}
-      />
-      <SavedBadge visible={saved} />
+    <div>
+      <div className="flex items-center gap-2">
+        <Input
+          {...props}
+          value={local}
+          onChange={(e) => {
+            setLocal(e.target.value);
+            onLocalChange?.(e.target.value);
+          }}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+          }}
+          className={`flex-1 ${error ? "border-destructive" : ""} ${props.className ?? ""}`}
+        />
+        <SavedBadge visible={saved} />
+      </div>
+      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add `HttpUrlSchema` (validate-only, no `.trim()`) and `SttModelEnum` to Zod schema; apply URL validation to `searxngUrl`, `ai.baseUrl`, `embedding.baseUrl` and constrain `stt.model` to Whisper sizes
- Add `validateHttpUrl` UI helper (owns normalization: trim + trailing slash removal) and enhance shared `DebouncedInput` with `error` prop and `onLocalChange` callback for instant inline validation feedback
- Wire URL validation in tools, AI, and memory settings sections; replace STT model free-text with `<Select>` dropdown; remove duplicate local component copies
- Add 22 new tests: `HttpUrlSchema` accepts/rejects, `SttModelEnum` enum, and patch pipeline regression tests

## Test plan

- [x] `bun test` -- 825 pass, 0 fail, full suite green
- [x] `tsc --noEmit` -- 0 type errors
- [ ] Manual: enter invalid URL in SearXNG/AI/Embedding settings, confirm inline error appears and clears on keystroke
- [ ] Manual: enter valid URL, confirm it saves and shows saved badge
- [ ] Manual: verify STT model dropdown shows all 5 sizes and persists selection


Made with [Cursor](https://cursor.com)