### PR TITLE
feat: tool runtime error surfacing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/cli": {
       "name": "@spaceduck/cli",
-      "version": "0.1.0",
+      "version": "0.17.0",
       "bin": {
         "spaceduck": "./src/index.ts",
       },
@@ -117,7 +117,7 @@
     },
     "packages/gateway": {
       "name": "@spaceduck/gateway",
-      "version": "0.1.0",
+      "version": "0.17.0",
       "dependencies": {
         "@spaceduck/channel-whatsapp": "workspace:*",
         "@spaceduck/config": "workspace:*",
@@ -284,6 +284,7 @@
         "react": "^19",
         "react-dom": "^19",
         "react-markdown": "^10.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
@@ -1884,6 +1885,8 @@
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/packages/gateway/src/tools/tools-status.ts
+++ b/packages/gateway/src/tools/tools-status.ts
@@ -1,0 +1,200 @@
+import type { ToolRegistry } from "@spaceduck/core";
+import type { ConfigStore } from "../config/config-store";
+import { MarkerTool } from "@spaceduck/tool-marker";
+
+export type ToolName = "web_search" | "web_answer" | "marker_scan";
+export type ToolStatus = "ok" | "error" | "not_configured" | "disabled" | "unavailable";
+
+export interface ToolErrorEvent {
+  tool: ToolName;
+  message: string;
+  timestamp: number;
+}
+
+export interface ToolStatusEntry {
+  tool: ToolName;
+  status: ToolStatus;
+  message?: string;
+  lastError?: { message: string; timestamp: number };
+}
+
+const MAX_ERRORS = 20;
+const ERROR_TTL_MS = 30 * 60 * 1000;
+
+export class ToolStatusService {
+  private errors: ToolErrorEvent[] = [];
+
+  constructor(
+    private readonly toolRegistry: ToolRegistry,
+    private readonly configStore?: ConfigStore,
+  ) {}
+
+  recordError(tool: ToolName, message: string): void {
+    this.errors.push({ tool, message, timestamp: Date.now() });
+    if (this.errors.length > MAX_ERRORS) {
+      this.errors = this.errors.slice(-MAX_ERRORS);
+    }
+  }
+
+  private pruneStale(): void {
+    const cutoff = Date.now() - ERROR_TTL_MS;
+    this.errors = this.errors.filter((e) => e.timestamp > cutoff);
+  }
+
+  private lastErrorFor(tool: ToolName): ToolErrorEvent | undefined {
+    for (let i = this.errors.length - 1; i >= 0; i--) {
+      if (this.errors[i].tool === tool) return this.errors[i];
+    }
+    return undefined;
+  }
+
+  getStatus(): ToolStatusEntry[] {
+    this.pruneStale();
+    const cfg = this.configStore?.current;
+
+    const entries: ToolStatusEntry[] = [];
+
+    entries.push(this.getWebSearchStatus(cfg));
+    entries.push(this.getWebAnswerStatus(cfg));
+    entries.push(this.getMarkerStatus(cfg));
+
+    return entries;
+  }
+
+  private getWebSearchStatus(cfg?: Record<string, unknown>): ToolStatusEntry {
+    const toolsCfg = cfg?.tools as Record<string, unknown> | undefined;
+    const ws = toolsCfg?.webSearch as Record<string, unknown> | undefined;
+    const provider = ws?.provider as string | null;
+
+    if (!provider) {
+      return { tool: "web_search", status: "not_configured", message: "No search provider selected" };
+    }
+
+    const registered = this.toolRegistry.has("web_search");
+    if (!registered) {
+      if (provider === "brave") {
+        return { tool: "web_search", status: "not_configured", message: "Brave API key not set (env: BRAVE_API_KEY)" };
+      }
+      if (provider === "searxng") {
+        const url = ws?.searxngUrl as string | null;
+        if (!url) {
+          return { tool: "web_search", status: "not_configured", message: "SearXNG URL not configured" };
+        }
+        return { tool: "web_search", status: "unavailable", message: "SearXNG URL set but tool not registered (check env: SEARXNG_URL)" };
+      }
+      return { tool: "web_search", status: "unavailable", message: "Tool not registered" };
+    }
+
+    const lastErr = this.lastErrorFor("web_search");
+    return {
+      tool: "web_search",
+      status: lastErr ? "error" : "ok",
+      lastError: lastErr ? { message: lastErr.message, timestamp: lastErr.timestamp } : undefined,
+    };
+  }
+
+  private getWebAnswerStatus(cfg?: Record<string, unknown>): ToolStatusEntry {
+    const toolsCfg = cfg?.tools as Record<string, unknown> | undefined;
+    const wa = toolsCfg?.webAnswer as Record<string, unknown> | undefined;
+    const enabled = (wa?.enabled as boolean) ?? true;
+
+    if (!enabled) {
+      return { tool: "web_answer", status: "disabled" };
+    }
+
+    const registered = this.toolRegistry.has("web_answer");
+    if (!registered) {
+      return { tool: "web_answer", status: "not_configured", message: "API key not set (env: PERPLEXITY_API_KEY or OPENROUTER_API_KEY)" };
+    }
+
+    const lastErr = this.lastErrorFor("web_answer");
+    return {
+      tool: "web_answer",
+      status: lastErr ? "error" : "ok",
+      lastError: lastErr ? { message: lastErr.message, timestamp: lastErr.timestamp } : undefined,
+    };
+  }
+
+  private getMarkerStatus(cfg?: Record<string, unknown>): ToolStatusEntry {
+    const toolsCfg = cfg?.tools as Record<string, unknown> | undefined;
+    const marker = toolsCfg?.marker as Record<string, unknown> | undefined;
+    const enabled = (marker?.enabled as boolean) ?? true;
+
+    if (!enabled) {
+      return { tool: "marker_scan", status: "disabled" };
+    }
+
+    const registered = this.toolRegistry.has("marker_scan");
+    if (!registered) {
+      return { tool: "marker_scan", status: "unavailable", message: "marker_single binary not found on PATH" };
+    }
+
+    const lastErr = this.lastErrorFor("marker_scan");
+    return {
+      tool: "marker_scan",
+      status: lastErr ? "error" : "ok",
+      lastError: lastErr ? { message: lastErr.message, timestamp: lastErr.timestamp } : undefined,
+    };
+  }
+
+  async probe(tool: ToolName): Promise<{ ok: boolean; message?: string; durationMs: number }> {
+    const start = Date.now();
+
+    switch (tool) {
+      case "web_search": {
+        if (!this.toolRegistry.has("web_search")) {
+          return { ok: false, message: "Tool not registered", durationMs: Date.now() - start };
+        }
+        try {
+          const result = await this.toolRegistry.execute({
+            id: `probe-${Date.now()}`,
+            name: "web_search",
+            args: { query: "test", count: 1 },
+          });
+          if (result.isError) {
+            this.recordError("web_search", result.content);
+            return { ok: false, message: result.content, durationMs: Date.now() - start };
+          }
+          return { ok: true, durationMs: Date.now() - start };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.recordError("web_search", msg);
+          return { ok: false, message: msg, durationMs: Date.now() - start };
+        }
+      }
+
+      case "web_answer": {
+        if (!this.toolRegistry.has("web_answer")) {
+          return { ok: false, message: "Tool not registered", durationMs: Date.now() - start };
+        }
+        try {
+          const result = await this.toolRegistry.execute({
+            id: `probe-${Date.now()}`,
+            name: "web_answer",
+            args: { query: "ping" },
+          });
+          if (result.isError) {
+            this.recordError("web_answer", result.content);
+            return { ok: false, message: result.content, durationMs: Date.now() - start };
+          }
+          return { ok: true, durationMs: Date.now() - start };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.recordError("web_answer", msg);
+          return { ok: false, message: msg, durationMs: Date.now() - start };
+        }
+      }
+
+      case "marker_scan": {
+        const available = await MarkerTool.isAvailable();
+        if (!available) {
+          return { ok: false, message: "marker_single binary not found", durationMs: Date.now() - start };
+        }
+        return { ok: true, durationMs: Date.now() - start };
+      }
+
+      default:
+        return { ok: false, message: `Unknown tool: ${tool}`, durationMs: Date.now() - start };
+    }
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,6 +34,7 @@
     "react": "^19",
     "react-dom": "^19",
     "react-markdown": "^10.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -6,6 +6,7 @@ import { ChatView } from "./components/chat-view";
 import { OnboardingView } from "./components/onboarding-view";
 import { SettingsView } from "./components/settings-view";
 import { TooltipProvider } from "./ui/tooltip";
+import { Toaster } from "sonner";
 
 export type AppView = "onboarding" | "chat" | "settings";
 
@@ -36,6 +37,7 @@ export function App() {
   return (
     <ThemeProvider>
       <AppInner />
+      <Toaster position="bottom-right" richColors closeButton />
     </ThemeProvider>
   );
 }

--- a/packages/ui/src/lib/tool-types.ts
+++ b/packages/ui/src/lib/tool-types.ts
@@ -1,0 +1,40 @@
+export type ToolName = "web_search" | "web_answer" | "marker_scan";
+
+export type ToolStatus = "ok" | "error" | "not_configured" | "disabled" | "unavailable";
+
+export interface ToolActivity {
+  toolCallId: string;
+  toolName: string;
+  startedAt: number;
+  result?: {
+    content: string;
+    isError: boolean;
+  };
+  completedAt?: number;
+}
+
+export interface ToolStatusEntry {
+  tool: ToolName;
+  status: ToolStatus;
+  message?: string;
+  lastError?: {
+    message: string;
+    timestamp: number;
+  };
+}
+
+export interface ToolStatusResponse {
+  tools: ToolStatusEntry[];
+}
+
+export interface ToolTestRequest {
+  tool: ToolName;
+  options?: Record<string, unknown>;
+}
+
+export interface ToolTestResponse {
+  tool: ToolName;
+  ok: boolean;
+  message?: string;
+  durationMs?: number;
+}


### PR DESCRIPTION
## Summary

- Surface tool errors (web_search, web_answer, marker_scan) to users via sonner toasts during chat, with fingerprint-based deduplication that resets on WS reconnect or stream completion
- Add `GET /api/tools/status` (cheap, cached) and `POST /api/tools/test` (active probe) endpoints backed by a `ToolStatusService` with in-memory error ring buffer
- Add live status indicators and Test buttons to the Tools settings page so users can verify tool health without leaving settings

Depends on #86.

## Test plan

- [x] `bun test` -- 825 pass, 0 fail
- [x] `tsc --noEmit` -- 0 type errors
- [ ] Manual: trigger a tool error (e.g. invalid SearXNG URL), confirm toast appears in chat
- [ ] Manual: send multiple messages that trigger the same tool error, confirm toast only appears once
- [ ] Manual: disconnect/reconnect WS, confirm dedupe set resets (new errors toast again)
- [ ] Manual: open Tools settings, verify status badges show for each tool
- [ ] Manual: click Test on each tool card, verify spinner + result display
- [ ] Manual: `curl -H "Authorization: Bearer $TOKEN" http://localhost:3000/api/tools/status` returns structured JSON


Made with [Cursor](https://cursor.com)