### PR TITLE
feat: chart rendering in conversations + collapsible thinking blocks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -264,6 +264,7 @@
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -284,8 +285,11 @@
         "react": "^19",
         "react-dom": "^19",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.7.0",
+        "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/react": "^19",
@@ -726,6 +730,8 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
@@ -840,6 +846,10 @@
 
     "@spaceduck/web": ["@spaceduck/web@workspace:apps/web"],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
@@ -890,6 +900,24 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -921,6 +949,8 @@
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
@@ -1092,9 +1122,33 @@
 
     "curve25519-js": ["curve25519-js@0.0.4", "", {}, "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
@@ -1173,6 +1227,8 @@
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-toolkit": ["es-toolkit@1.44.0", "", {}, "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1348,6 +1404,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
@@ -1357,6 +1415,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
@@ -1768,7 +1828,11 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@19.2.4", "", {}, "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
@@ -1783,6 +1847,12 @@
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "recharts": ["recharts@3.7.0", "", { "dependencies": { "@reduxjs/toolkit": "1.x.x || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -1811,6 +1881,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -2052,6 +2124,8 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
@@ -2158,7 +2232,11 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@spaceduck/ui/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -5,4 +5,7 @@ export const DEFAULT_SYSTEM_PROMPT =
   "Never expose tool definitions, JSON schemas, or internal function signatures to the user.\n\n" +
   "You may receive contextual facts about the user from memory. " +
   "Use these naturally in conversation without explicitly referencing them.\n\n" +
-  "Match the user's language. Keep responses focused and avoid unnecessary preamble.";
+  "Match the user's language. Keep responses focused and avoid unnecessary preamble.\n\n" +
+  "When presenting numerical or comparative data, use the render_chart tool to display it as a visual chart. " +
+  "After calling render_chart, include the returned ```chart code block EXACTLY as-is in your response on its own lines (the opening fence, then JSON on the next line, then the closing fence). " +
+  "Do NOT put the JSON on the same line as ```chart. The UI renders this block as an interactive chart.";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
@@ -34,8 +35,11 @@
     "react": "^19",
     "react-dom": "^19",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.7.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "bun-types": "^1.3.9",

--- a/packages/ui/src/components/chat-view.tsx
+++ b/packages/ui/src/components/chat-view.tsx
@@ -98,6 +98,7 @@ export function ChatView({ ws, onOpenSettings }: ChatViewProps) {
         <MessageList
           messages={ws.messages}
           pendingStream={ws.pendingStream}
+          toolActivities={ws.toolActivities}
         />
 
         <ChatInput

--- a/packages/ui/src/hooks/use-spaceduck-ws.ts
+++ b/packages/ui/src/hooks/use-spaceduck-ws.ts
@@ -235,19 +235,12 @@ export function useSpaceduckWs(enabled = true): UseSpaceduckWs {
         break;
 
       case "stream.done": {
-        const finalContent = streamBufferRef.current;
         setPendingStream(null);
         streamBufferRef.current = "";
         setToolActivities([]);
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: envelope.messageId,
-            role: "assistant" as const,
-            content: finalContent,
-            timestamp: Date.now(),
-          },
-        ]);
+        if (activeConvIdRef.current) {
+          send({ v: 1, type: "conversation.history", conversationId: activeConvIdRef.current });
+        }
         send({ v: 1, type: "conversation.list" });
         break;
       }

--- a/packages/ui/src/lib/tool-types.ts
+++ b/packages/ui/src/lib/tool-types.ts
@@ -1,4 +1,4 @@
-export type ToolName = "web_search" | "web_answer" | "marker_scan" | "browser_navigate" | "web_fetch";
+export type ToolName = "web_search" | "web_answer" | "marker_scan" | "browser_navigate" | "web_fetch" | "render_chart";
 
 export type ToolStatus = "ok" | "error" | "not_configured" | "disabled" | "unavailable";
 

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -23,6 +23,11 @@
   --sd-ring: 262 55% 57% / 0.3;
   --sd-popover: 0 0% 100%;
   --sd-popover-foreground: 240 10% 4%;
+  --sd-chart-1: 262 55% 57%;
+  --sd-chart-2: 173 58% 39%;
+  --sd-chart-3: 43 74% 66%;
+  --sd-chart-4: 12 76% 61%;
+  --sd-chart-5: 197 37% 46%;
 }
 
 .dark {
@@ -45,6 +50,11 @@
   --sd-ring: 262 55% 63% / 0.3;
   --sd-popover: 240 10% 8%;
   --sd-popover-foreground: 0 0% 98%;
+  --sd-chart-1: 262 55% 63%;
+  --sd-chart-2: 173 58% 52%;
+  --sd-chart-3: 43 74% 70%;
+  --sd-chart-4: 12 76% 65%;
+  --sd-chart-5: 197 37% 58%;
 }
 
 @theme inline {

--- a/packages/ui/src/ui/__tests__/chart-block.test.ts
+++ b/packages/ui/src/ui/__tests__/chart-block.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "bun:test";
+import { tryParseChartSpec } from "../chart-types";
+
+// These tests verify the integration seam between the markdown renderer
+// and the chart system. They test the exact strings that react-markdown
+// would pass through as code block children.
+
+function fencedBlockContent(json: string): string {
+  // react-markdown strips the fence markers and passes the raw content
+  // as children, with a trailing newline
+  return json + "\n";
+}
+
+describe("chart block integration seam", () => {
+  test("valid chart JSON parses correctly after trailing newline strip", () => {
+    const raw = fencedBlockContent(
+      JSON.stringify({
+        type: "bar",
+        data: [{ x: "A", y: 10 }],
+        xKey: "x",
+        series: [{ key: "y" }],
+      }),
+    );
+    // The message-list.tsx code calls raw.replace(/\n$/, "")
+    const cleaned = raw.replace(/\n$/, "");
+    const result = tryParseChartSpec(cleaned);
+    expect(result.ok).toBe(true);
+  });
+
+  test("non-chart language code blocks would not be passed to ChartBlock", () => {
+    const tsCode = "const x: number = 42;";
+    const result = tryParseChartSpec(tsCode);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("invalid_json");
+  });
+
+  test("inline code snippets containing 'chart' do not parse as charts", () => {
+    const result = tryParseChartSpec("chart");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe("invalid_json");
+  });
+
+  test("children array joining produces parseable JSON", () => {
+    // react-markdown can pass children as arrays
+    const parts = ['{"type":"bar","data":[', '{"x":"A","y":1}', '],"xKey":"x","series":[{"key":"y"}]}'];
+    const joined = parts.join("");
+    const result = tryParseChartSpec(joined);
+    expect(result.ok).toBe(true);
+  });
+
+  test("pretty-printed JSON from LLM parses correctly", () => {
+    const prettyJson = `{
+  "version": 1,
+  "type": "bar",
+  "title": "Monthly Revenue",
+  "data": [
+    { "month": "Jan", "revenue": 4000 },
+    { "month": "Feb", "revenue": 3000 },
+    { "month": "Mar", "revenue": 5200 }
+  ],
+  "xKey": "month",
+  "series": [
+    { "key": "revenue", "label": "Revenue" }
+  ]
+}`;
+    const result = tryParseChartSpec(prettyJson);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.spec.title).toBe("Monthly Revenue");
+      expect(result.spec.type).toBe("bar");
+    }
+  });
+
+  test("JSON with extra whitespace and newlines still parses", () => {
+    const messy = `  \n  {"type":"pie","data":[{"name":"A","val":1}],"nameKey":"name","valueKey":"val"}  \n  `;
+    const result = tryParseChartSpec(messy.trim());
+    expect(result.ok).toBe(true);
+  });
+});

--- a/packages/ui/src/ui/__tests__/chart-types.test.ts
+++ b/packages/ui/src/ui/__tests__/chart-types.test.ts
@@ -1,0 +1,389 @@
+import { describe, test, expect } from "bun:test";
+import { tryParseChartSpec } from "../chart-types";
+import type { ChartParseErrorCode } from "../chart-types";
+
+function validBar(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    type: "bar",
+    data: [
+      { month: "Jan", revenue: 4000 },
+      { month: "Feb", revenue: 3000 },
+    ],
+    xKey: "month",
+    series: [{ key: "revenue", label: "Revenue" }],
+    ...overrides,
+  });
+}
+
+function validPie(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    type: "pie",
+    data: [
+      { source: "Organic", value: 42 },
+      { source: "Direct", value: 31 },
+    ],
+    nameKey: "source",
+    valueKey: "value",
+    ...overrides,
+  });
+}
+
+function expectError(input: string, code: ChartParseErrorCode) {
+  const result = tryParseChartSpec(input);
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.code).toBe(code);
+  }
+}
+
+describe("tryParseChartSpec", () => {
+  describe("valid specs", () => {
+    test("bar chart with defaults applied", () => {
+      const result = tryParseChartSpec(validBar());
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.spec.type).toBe("bar");
+        expect(result.spec.version).toBe(1);
+        expect(result.spec.height).toBe(240);
+        if (result.spec.type !== "pie") {
+          expect(result.spec.stacked).toBe(false);
+        }
+      }
+    });
+
+    test("line chart", () => {
+      const result = tryParseChartSpec(validBar({ type: "line" }));
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.spec.type).toBe("line");
+    });
+
+    test("area chart", () => {
+      const result = tryParseChartSpec(validBar({ type: "area" }));
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.spec.type).toBe("area");
+    });
+
+    test("pie chart", () => {
+      const result = tryParseChartSpec(validPie());
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.spec.type).toBe("pie");
+        if (result.spec.type === "pie") {
+          expect(result.spec.donut).toBe(false);
+        }
+      }
+    });
+
+    test("pie chart with donut", () => {
+      const result = tryParseChartSpec(validPie({ donut: true }));
+      expect(result.ok).toBe(true);
+      if (result.ok && result.spec.type === "pie") {
+        expect(result.spec.donut).toBe(true);
+      }
+    });
+
+    test("version field defaults to 1 when omitted", () => {
+      const result = tryParseChartSpec(validBar());
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.spec.version).toBe(1);
+    });
+
+    test("explicit version preserved", () => {
+      const result = tryParseChartSpec(validBar({ version: 2 }));
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.spec.version).toBe(2);
+    });
+
+    test("optional kind field accepted", () => {
+      const result = tryParseChartSpec(validBar({ kind: "chart" }));
+      expect(result.ok).toBe(true);
+    });
+
+    test("custom height within range", () => {
+      const result = tryParseChartSpec(validBar({ height: 300 }));
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.spec.height).toBe(300);
+    });
+
+    test("stacked bar chart", () => {
+      const result = tryParseChartSpec(
+        JSON.stringify({
+          type: "bar",
+          data: [{ month: "Jan", a: 10, b: 20 }],
+          xKey: "month",
+          series: [{ key: "a" }, { key: "b" }],
+          stacked: true,
+        }),
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok && result.spec.type !== "pie") {
+        expect(result.spec.stacked).toBe(true);
+      }
+    });
+
+    test("title and description preserved", () => {
+      const result = tryParseChartSpec(
+        validBar({ title: "My Chart", description: "Some details" }),
+      );
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.spec.title).toBe("My Chart");
+        expect(result.spec.description).toBe("Some details");
+      }
+    });
+  });
+
+  describe("invalid_json", () => {
+    test("malformed JSON", () => {
+      expectError("{nope}", "invalid_json");
+    });
+
+    test("empty string", () => {
+      expectError("", "invalid_json");
+    });
+
+    test("plain text", () => {
+      expectError("not json at all", "invalid_json");
+    });
+  });
+
+  describe("unsupported_type", () => {
+    test("radar type", () => {
+      expectError(
+        JSON.stringify({ type: "radar", data: [{ a: 1 }] }),
+        "unsupported_type",
+      );
+    });
+
+    test("scatter type", () => {
+      expectError(
+        JSON.stringify({ type: "scatter", data: [] }),
+        "unsupported_type",
+      );
+    });
+
+    test("heatmap type", () => {
+      expectError(
+        JSON.stringify({ type: "heatmap", data: [] }),
+        "unsupported_type",
+      );
+    });
+  });
+
+  describe("too_many_rows", () => {
+    test("51 data rows rejected", () => {
+      const data = Array.from({ length: 51 }, (_, i) => ({
+        x: `item-${i}`,
+        y: i,
+      }));
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data,
+          xKey: "x",
+          series: [{ key: "y" }],
+        }),
+        "too_many_rows",
+      );
+    });
+
+    test("50 data rows accepted", () => {
+      const data = Array.from({ length: 50 }, (_, i) => ({
+        x: `item-${i}`,
+        y: i,
+      }));
+      const result = tryParseChartSpec(
+        JSON.stringify({
+          type: "bar",
+          data,
+          xKey: "x",
+          series: [{ key: "y" }],
+        }),
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("too_many_series", () => {
+    test("9 series rejected", () => {
+      const series = Array.from({ length: 9 }, (_, i) => ({
+        key: `s${i}`,
+      }));
+      const row: Record<string, unknown> = { x: "a" };
+      for (const s of series) row[s.key] = 1;
+
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [row],
+          xKey: "x",
+          series,
+        }),
+        "too_many_series",
+      );
+    });
+
+    test("8 series accepted", () => {
+      const series = Array.from({ length: 8 }, (_, i) => ({
+        key: `s${i}`,
+      }));
+      const row: Record<string, unknown> = { x: "a" };
+      for (const s of series) row[s.key] = 1;
+
+      const result = tryParseChartSpec(
+        JSON.stringify({
+          type: "bar",
+          data: [row],
+          xKey: "x",
+          series,
+        }),
+      );
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("invalid_schema", () => {
+    test("missing type field", () => {
+      expectError(
+        JSON.stringify({ data: [{ x: 1 }], xKey: "x", series: [{ key: "x" }] }),
+        "invalid_schema",
+      );
+    });
+
+    test("missing xKey for cartesian chart", () => {
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [{ month: "Jan", rev: 100 }],
+          series: [{ key: "rev" }],
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("missing series for cartesian chart", () => {
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [{ month: "Jan", rev: 100 }],
+          xKey: "month",
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("missing nameKey for pie chart", () => {
+      expectError(
+        JSON.stringify({
+          type: "pie",
+          data: [{ source: "A", value: 1 }],
+          valueKey: "value",
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("missing valueKey for pie chart", () => {
+      expectError(
+        JSON.stringify({
+          type: "pie",
+          data: [{ source: "A", value: 1 }],
+          nameKey: "source",
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("empty data array", () => {
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [],
+          xKey: "x",
+          series: [{ key: "y" }],
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("non-object input (array)", () => {
+      expectError("[1, 2, 3]", "invalid_schema");
+    });
+
+    test("non-object input (string)", () => {
+      expectError('"just a string"', "invalid_schema");
+    });
+
+    test("height below minimum", () => {
+      expectError(validBar({ height: 50 }), "invalid_schema");
+    });
+
+    test("height above maximum", () => {
+      expectError(validBar({ height: 500 }), "invalid_schema");
+    });
+  });
+
+  describe("superRefine: data integrity", () => {
+    test("missing xKey in row", () => {
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [{ rev: 100 }],
+          xKey: "month",
+          series: [{ key: "rev" }],
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("non-numeric series value (string)", () => {
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [{ month: "Jan", revenue: "four thousand" }],
+          xKey: "month",
+          series: [{ key: "revenue" }],
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("non-numeric series value (NaN)", () => {
+      // NaN can't be in JSON, but Infinity can't either.
+      // This tests the missing key path instead.
+      expectError(
+        JSON.stringify({
+          type: "bar",
+          data: [{ month: "Jan" }],
+          xKey: "month",
+          series: [{ key: "revenue" }],
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("missing nameKey in pie row", () => {
+      expectError(
+        JSON.stringify({
+          type: "pie",
+          data: [{ value: 42 }],
+          nameKey: "source",
+          valueKey: "value",
+        }),
+        "invalid_schema",
+      );
+    });
+
+    test("non-numeric valueKey in pie row", () => {
+      expectError(
+        JSON.stringify({
+          type: "pie",
+          data: [{ source: "Organic", value: "forty-two" }],
+          nameKey: "source",
+          valueKey: "value",
+        }),
+        "invalid_schema",
+      );
+    });
+  });
+});

--- a/packages/ui/src/ui/chart-block.tsx
+++ b/packages/ui/src/ui/chart-block.tsx
@@ -1,0 +1,28 @@
+import { tryParseChartSpec } from "./chart-types";
+import { ChartRenderer } from "./chart-renderer";
+
+function ChartCodeFallback({ raw, reason }: { raw: string; reason?: string }) {
+  return (
+    <div>
+      {reason && (
+        <p className="text-xs text-muted-foreground mb-1 italic">{reason}</p>
+      )}
+      <pre className="bg-background/50 rounded-lg p-3">
+        <code className="text-primary font-mono text-sm whitespace-pre-wrap">{raw}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function ChartBlock({ raw }: { raw: string }) {
+  const result = tryParseChartSpec(raw);
+
+  if (!result.ok) {
+    const reason = result.code === "unsupported_type"
+      ? result.error
+      : undefined;
+    return <ChartCodeFallback raw={raw} reason={reason} />;
+  }
+
+  return <ChartRenderer spec={result.spec} />;
+}

--- a/packages/ui/src/ui/chart-renderer.tsx
+++ b/packages/ui/src/ui/chart-renderer.tsx
@@ -1,0 +1,165 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import type { ChartSpec, CartesianChartSpec, PieChartSpec } from "./chart-types";
+import { chartColor } from "./chart-types";
+
+interface ChartRendererProps {
+  spec: ChartSpec;
+}
+
+const GRID_STYLE = { strokeDasharray: "3 3", stroke: "hsl(var(--sd-border))" };
+const AXIS_STYLE = {
+  fontSize: 11,
+  tickLine: false,
+  axisLine: false,
+  stroke: "hsl(var(--sd-muted-foreground))",
+} as const;
+
+const TOOLTIP_STYLE = {
+  contentStyle: {
+    backgroundColor: "hsl(var(--sd-popover))",
+    border: "1px solid hsl(var(--sd-border))",
+    borderRadius: 6,
+    fontSize: 12,
+    color: "hsl(var(--sd-popover-foreground))",
+  },
+  cursor: { fill: "hsl(var(--sd-muted))" },
+};
+
+function CartesianChart({ spec }: { spec: CartesianChartSpec }) {
+  const showLegend = spec.series.length > 1;
+
+  const sharedChildren = (
+    <>
+      <CartesianGrid {...GRID_STYLE} />
+      <XAxis dataKey={spec.xKey} {...AXIS_STYLE} />
+      <Tooltip {...TOOLTIP_STYLE} />
+      {showLegend && (
+        <Legend
+          iconSize={8}
+          wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+        />
+      )}
+    </>
+  );
+
+  if (spec.type === "bar") {
+    return (
+      <BarChart data={spec.data}>
+        {sharedChildren}
+        {spec.series.map((s, i) => (
+          <Bar
+            key={s.key}
+            dataKey={s.key}
+            name={s.label ?? s.key}
+            fill={chartColor(i)}
+            radius={[3, 3, 0, 0]}
+            stackId={spec.stacked ? "stack" : undefined}
+          />
+        ))}
+      </BarChart>
+    );
+  }
+
+  if (spec.type === "line") {
+    return (
+      <LineChart data={spec.data}>
+        {sharedChildren}
+        {spec.series.map((s, i) => (
+          <Line
+            key={s.key}
+            type="monotone"
+            dataKey={s.key}
+            name={s.label ?? s.key}
+            stroke={chartColor(i)}
+            strokeWidth={2}
+            dot={spec.data.length <= 20}
+            activeDot={{ r: 4 }}
+          />
+        ))}
+      </LineChart>
+    );
+  }
+
+  // area
+  return (
+    <AreaChart data={spec.data}>
+      {sharedChildren}
+      {spec.series.map((s, i) => (
+        <Area
+          key={s.key}
+          type="monotone"
+          dataKey={s.key}
+          name={s.label ?? s.key}
+          stroke={chartColor(i)}
+          fill={chartColor(i)}
+          fillOpacity={0.2}
+          strokeWidth={2}
+          stackId={spec.stacked ? "stack" : undefined}
+        />
+      ))}
+    </AreaChart>
+  );
+}
+
+function PieChartComponent({ spec }: { spec: PieChartSpec }) {
+  return (
+    <PieChart>
+      <Pie
+        data={spec.data}
+        dataKey={spec.valueKey}
+        nameKey={spec.nameKey}
+        cx="50%"
+        cy="50%"
+        innerRadius={spec.donut ? "40%" : 0}
+        outerRadius="75%"
+        paddingAngle={spec.data.length > 1 ? 2 : 0}
+        label={({ name, percent }) =>
+          `${name} ${(percent * 100).toFixed(0)}%`
+        }
+        labelLine={false}
+        fontSize={11}
+      >
+        {spec.data.map((_, i) => (
+          <Cell key={i} fill={chartColor(i)} />
+        ))}
+      </Pie>
+      <Tooltip {...TOOLTIP_STYLE} />
+      <Legend iconSize={8} wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />
+    </PieChart>
+  );
+}
+
+export function ChartRenderer({ spec }: ChartRendererProps) {
+  return (
+    <div className="my-2">
+      {spec.title && (
+        <p className="text-sm font-medium mb-0.5">{spec.title}</p>
+      )}
+      {spec.description && (
+        <p className="text-xs text-muted-foreground mb-1">{spec.description}</p>
+      )}
+      <ResponsiveContainer width="100%" height={spec.height}>
+        {spec.type === "pie" ? (
+          <PieChartComponent spec={spec} />
+        ) : (
+          <CartesianChart spec={spec} />
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/packages/ui/src/ui/chart-types.ts
+++ b/packages/ui/src/ui/chart-types.ts
@@ -1,0 +1,188 @@
+import { z } from "zod/v4";
+
+// ── Error codes ────────────────────────────────────────────────────────
+
+export type ChartParseErrorCode =
+  | "invalid_json"
+  | "invalid_schema"
+  | "unsupported_type"
+  | "too_many_rows"
+  | "too_many_series";
+
+export type ChartParseResult =
+  | { ok: true; spec: ChartSpec }
+  | { ok: false; code: ChartParseErrorCode; error: string };
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const SUPPORTED_TYPES = ["bar", "line", "area", "pie"] as const;
+const MAX_DATA_ROWS = 50;
+const MAX_SERIES = 8;
+const DEFAULT_HEIGHT = 240;
+const MAX_HEIGHT = 400;
+
+// ── Shared fields ──────────────────────────────────────────────────────
+
+const dataRow = z.record(z.string(), z.union([z.string(), z.number()]));
+
+const seriesItem = z.object({
+  key: z.string(),
+  label: z.string().optional(),
+});
+
+const baseFields = {
+  version: z.number().optional().default(1),
+  kind: z.literal("chart").optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  height: z.number().min(100).max(MAX_HEIGHT).optional().default(DEFAULT_HEIGHT),
+};
+
+// ── Cartesian schema (bar, line, area) ─────────────────────────────────
+
+const cartesianSchema = z
+  .object({
+    ...baseFields,
+    type: z.enum(["bar", "line", "area"]),
+    data: z.array(dataRow).min(1).max(MAX_DATA_ROWS),
+    xKey: z.string(),
+    series: z.array(seriesItem).min(1).max(MAX_SERIES),
+    stacked: z.boolean().optional().default(false),
+  })
+  .superRefine((spec, ctx) => {
+    for (let i = 0; i < spec.data.length; i++) {
+      const row = spec.data[i];
+      if (!(spec.xKey in row)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Row ${i} is missing xKey "${spec.xKey}"`,
+          path: ["data", i],
+        });
+        return;
+      }
+      for (const s of spec.series) {
+        const val = row[s.key];
+        if (val === undefined || typeof val !== "number" || !Number.isFinite(val)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Row ${i} has non-numeric value for series key "${s.key}"`,
+            path: ["data", i, s.key],
+          });
+          return;
+        }
+      }
+    }
+  });
+
+// ── Pie schema ─────────────────────────────────────────────────────────
+
+const pieSchema = z
+  .object({
+    ...baseFields,
+    type: z.literal("pie"),
+    data: z.array(dataRow).min(1).max(MAX_DATA_ROWS),
+    nameKey: z.string(),
+    valueKey: z.string(),
+    donut: z.boolean().optional().default(false),
+  })
+  .superRefine((spec, ctx) => {
+    for (let i = 0; i < spec.data.length; i++) {
+      const row = spec.data[i];
+      if (!(spec.nameKey in row)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Row ${i} is missing nameKey "${spec.nameKey}"`,
+          path: ["data", i],
+        });
+        return;
+      }
+      const val = row[spec.valueKey];
+      if (val === undefined || typeof val !== "number" || !Number.isFinite(val)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Row ${i} has non-numeric value for valueKey "${spec.valueKey}"`,
+          path: ["data", i, spec.valueKey],
+        });
+        return;
+      }
+    }
+  });
+
+// ── Combined schema ────────────────────────────────────────────────────
+
+const chartSpecSchema = z.discriminatedUnion("type", [
+  cartesianSchema,
+  pieSchema,
+]);
+
+export type CartesianChartSpec = z.infer<typeof cartesianSchema>;
+export type PieChartSpec = z.infer<typeof pieSchema>;
+export type ChartSpec = z.infer<typeof chartSpecSchema>;
+
+// ── Chart colors (indices into CSS variables) ──────────────────────────
+
+export const CHART_COLORS = [
+  "hsl(var(--sd-chart-1))",
+  "hsl(var(--sd-chart-2))",
+  "hsl(var(--sd-chart-3))",
+  "hsl(var(--sd-chart-4))",
+  "hsl(var(--sd-chart-5))",
+] as const;
+
+export function chartColor(index: number): string {
+  return CHART_COLORS[index % CHART_COLORS.length];
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────
+
+export function tryParseChartSpec(input: string): ChartParseResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(input);
+  } catch {
+    return { ok: false, code: "invalid_json", error: "Invalid JSON" };
+  }
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { ok: false, code: "invalid_schema", error: "Chart spec must be a JSON object" };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // Pre-check for better error code differentiation before Zod runs
+  if (typeof obj.type === "string" && !(SUPPORTED_TYPES as readonly string[]).includes(obj.type)) {
+    return {
+      ok: false,
+      code: "unsupported_type",
+      error: `Unsupported chart type "${obj.type}". Supported: ${SUPPORTED_TYPES.join(", ")}`,
+    };
+  }
+
+  if (Array.isArray(obj.data) && obj.data.length > MAX_DATA_ROWS) {
+    return {
+      ok: false,
+      code: "too_many_rows",
+      error: `Too many data rows (${obj.data.length}). Maximum: ${MAX_DATA_ROWS}`,
+    };
+  }
+
+  if (Array.isArray(obj.series) && obj.series.length > MAX_SERIES) {
+    return {
+      ok: false,
+      code: "too_many_series",
+      error: `Too many series (${obj.series.length}). Maximum: ${MAX_SERIES}`,
+    };
+  }
+
+  const result = chartSpecSchema.safeParse(raw);
+  if (!result.success) {
+    const firstIssue = result.error.issues[0];
+    return {
+      ok: false,
+      code: "invalid_schema",
+      error: firstIssue?.message ?? "Invalid chart schema",
+    };
+  }
+
+  return { ok: true, spec: result.data };
+}

--- a/packages/ui/src/ui/collapsible.tsx
+++ b/packages/ui/src/ui/collapsible.tsx
@@ -1,0 +1,7 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+const Collapsible = CollapsiblePrimitive.Root;
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };


### PR DESCRIPTION
## Summary

- **Interactive chart rendering**: Assistant can call `render_chart` or emit `chart` code blocks directly. The UI renders bar, line, area, and pie charts via Recharts with Zod-validated specs, compact chat styling, theme-aware colors, and safe fallback on parse failure.
- **Collapsible thinking blocks**: Intermediate tool-use messages (browser navigate, evaluate, etc.) collapse into expandable `ThinkingBlock` using shadcn Collapsible. Live `StreamingThinkingBlock` shows tool execution in real-time during streaming. On `stream.done`, conversation history is reloaded for clean message grouping.
- **Agent loop improvements**: `maxToolRounds` increased from 10 to 20 for complex multi-step workflows (scrape + process + render). Tool definitions are now passed on every round for Bedrock compatibility.

## New files

- `packages/ui/src/ui/chart-types.ts` — Zod schemas + parser
- `packages/ui/src/ui/chart-renderer.tsx` — Recharts rendering
- `packages/ui/src/ui/chart-block.tsx` — parse/validate/fallback wrapper
- `packages/ui/src/ui/collapsible.tsx` — shadcn Collapsible component
- `packages/ui/src/ui/__tests__/chart-types.test.ts` — schema validation tests
- `packages/ui/src/ui/__tests__/chart-block.test.ts` — integration tests

## Test plan

- [ ] Ask Spaceduck "Show me a bar chart of planets by number of moons" — should render interactive chart
- [ ] Ask Spaceduck to scrape a dynamic page and chart the data — model should use browser tools then render_chart
- [ ] Verify ThinkingBlock appears (collapsed) after tool-heavy response completes
- [ ] Expand ThinkingBlock to see intermediate tool calls
- [ ] Verify chart fallback: invalid JSON renders as code block, unsupported type shows note
- [ ] Run `bun test` in `packages/ui` — chart-types and chart-block tests pass


Made with [Cursor](https://cursor.com)