### PR TITLE
fix: strip trailing assistant messages for Bedrock compatibility

### DIFF
--- a/packages/providers/bedrock/src/index.ts
+++ b/packages/providers/bedrock/src/index.ts
@@ -180,6 +180,14 @@ function mergeConsecutive(messages: ConverseMessage[]): ConverseMessage[] {
       result.push({ role: msg.role, content: [...msg.content] });
     }
   }
+
+  // Bedrock requires the conversation to end with a user message.
+  // Strip any trailing assistant messages to avoid "does not support
+  // assistant message prefill" errors.
+  while (result.length > 0 && result[result.length - 1].role === "assistant") {
+    result.pop();
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

- Strip trailing assistant messages in the Bedrock provider's `mergeConsecutive` function before sending to the Converse API
- Bedrock requires conversations to end with a user message; intermediate assistant messages with tool calls can violate this, causing "does not support assistant message prefill" errors

## Test plan

- [ ] Multi-round tool use conversations work without prefill errors on Bedrock
- [ ] Single-round conversations (no tool use) unaffected

Made with [Cursor](https://cursor.com)