### PR TITLE
feat(browser): live preview panel with CDP screencast streaming

### DIFF
--- a/docs/tools/browser.mdx
+++ b/docs/tools/browser.mdx
@@ -89,6 +89,38 @@ Avoid `state: "networkidle"` on single-page applications — SPAs never stop mak
 | `maxResultChars` | 50,000 | Max characters returned from snapshots and evaluate |
 | `defaultTimeout` | 30,000 ms | Timeout for page actions |
 
+## Live Preview
+
+When enabled, a real-time browser view panel appears on the right side of the chat while the assistant is browsing. You can watch navigation, clicks, form fills, and page transitions as they happen.
+
+Live Preview uses Chrome DevTools Protocol [screencast](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast) to stream compressed JPEG frames directly from Chromium — the same technology that powers Chrome's remote debugging. Frames are only pushed when the page visually changes, so bandwidth is naturally throttled.
+
+### Enabling Live Preview
+
+Live Preview is **disabled by default**. To turn it on:
+
+1. Go to **Settings → Tools → Browser**
+2. Toggle **Live Preview** on
+
+Or set it via the config file:
+
+```json5
+{
+  tools: {
+    browser: {
+      enabled: true,
+      livePreview: true
+    }
+  }
+}
+```
+
+The setting is hot-applied — no gateway restart required.
+
+<Note>
+Live Preview adds ~20–50 KB per frame over the WebSocket connection. On typical browsing sessions this is well within normal bandwidth, but you may want to disable it on very slow connections.
+</Note>
+
 ## When to use browser vs web fetch
 
 | Use browser when | Use web fetch when |

--- a/packages/config/src/hot-apply.ts
+++ b/packages/config/src/hot-apply.ts
@@ -21,6 +21,7 @@ export const HOT_APPLY_PATHS: ReadonlySet<string> = new Set([
   "/stt/awsTranscribe/profile",
   "/stt/dictation/enabled",
   "/stt/dictation/hotkey",
+  "/tools/browser/livePreview",
   "/tools/marker/enabled",
   "/tools/webSearch/provider",
   "/tools/webSearch/searxngUrl",

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -103,6 +103,7 @@ const MarkerSchema = z.object({
 
 const BrowserSchema = z.object({
   enabled: z.boolean().default(true),
+  livePreview: z.boolean().default(false),
 });
 
 const WebFetchSchema = z.object({

--- a/packages/core/src/types/protocol.ts
+++ b/packages/core/src/types/protocol.ts
@@ -24,6 +24,8 @@ export type WsServerEnvelope =
   | { v: 1; type: "stream.error"; requestId: string; code: string; message: string }
   | { v: 1; type: "tool.calling"; requestId: string; toolCall: ToolCall }
   | { v: 1; type: "tool.result"; requestId: string; toolResult: ToolResult }
+  | { v: 1; type: "browser.frame"; requestId: string; data: string; format: "jpeg" | "png"; url: string }
+  | { v: 1; type: "browser.frame"; requestId: string; closed: true }
   | { v: 1; type: "conversation.list"; conversations: ConversationSummary[] }
   | { v: 1; type: "conversation.history"; conversationId: string; messages: Message[] }
   | { v: 1; type: "conversation.created"; conversationId: string }

--- a/packages/gateway/src/browser-frame-target.ts
+++ b/packages/gateway/src/browser-frame-target.ts
@@ -1,0 +1,35 @@
+import type { WsServerEnvelope } from "@spaceduck/core";
+import type { ScreencastFrame } from "@spaceduck/tool-browser";
+
+export interface BrowserFrameTarget {
+  ws: { send(data: string): void } | null;
+  requestId: string;
+}
+
+export function createBrowserFrameTarget(): {
+  target: BrowserFrameTarget;
+  onFrame: (frame: ScreencastFrame | { closed: true }) => void;
+} {
+  const target: BrowserFrameTarget = { ws: null, requestId: "" };
+
+  function onFrame(frame: ScreencastFrame | { closed: true }): void {
+    if (!target.ws) return;
+
+    let envelope: WsServerEnvelope;
+    if ("closed" in frame) {
+      envelope = { v: 1, type: "browser.frame", requestId: target.requestId, closed: true };
+    } else {
+      envelope = {
+        v: 1,
+        type: "browser.frame",
+        requestId: target.requestId,
+        data: frame.base64,
+        format: frame.format,
+        url: frame.url,
+      };
+    }
+    target.ws.send(JSON.stringify(envelope));
+  }
+
+  return { target, onFrame };
+}

--- a/packages/tools/browser/src/index.ts
+++ b/packages/tools/browser/src/index.ts
@@ -1,2 +1,10 @@
 export { BrowserTool } from "./browser-tool";
-export type { BrowserToolOptions, SnapshotNode, WaitOptions, RefEntry } from "./types";
+export type {
+  BrowserToolOptions,
+  ScreencastOptions,
+  ScreencastFrame,
+  ScreencastFrameCallback,
+  SnapshotNode,
+  WaitOptions,
+  RefEntry,
+} from "./types";

--- a/packages/tools/browser/src/types.ts
+++ b/packages/tools/browser/src/types.ts
@@ -6,6 +6,21 @@ export interface BrowserToolOptions {
   defaultTimeout?: number;
 }
 
+export interface ScreencastOptions {
+  format?: "jpeg" | "png";
+  quality?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+export interface ScreencastFrame {
+  base64: string;
+  format: "jpeg" | "png";
+  url: string;
+}
+
+export type ScreencastFrameCallback = (frame: ScreencastFrame) => void;
+
 export interface SnapshotNode {
   ref: number;
   role: string;

--- a/packages/ui/src/components/browser-preview-panel.tsx
+++ b/packages/ui/src/components/browser-preview-panel.tsx
@@ -1,0 +1,49 @@
+import type { BrowserPreview } from "../hooks/use-spaceduck-ws";
+import { Globe, Monitor } from "lucide-react";
+
+interface BrowserPreviewPanelProps {
+  preview: BrowserPreview;
+}
+
+function truncateUrl(url: string, maxLen = 40): string {
+  try {
+    const parsed = new URL(url);
+    const display = parsed.hostname + parsed.pathname;
+    return display.length > maxLen ? display.slice(0, maxLen) + "…" : display;
+  } catch {
+    return url.length > maxLen ? url.slice(0, maxLen) + "…" : url;
+  }
+}
+
+export function BrowserPreviewPanel({ preview }: BrowserPreviewPanelProps) {
+  return (
+    <div className="flex flex-col h-full border-l border-border bg-background">
+      {/* Address bar */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/30">
+        <Globe size={14} className="text-muted-foreground shrink-0" />
+        <span className="text-xs text-muted-foreground truncate font-mono">
+          {truncateUrl(preview.url, 50)}
+        </span>
+      </div>
+
+      {/* Frame */}
+      <div className="flex-1 min-h-0 flex items-center justify-center p-2 bg-black/20">
+        <img
+          src={preview.dataUrl}
+          alt="Live browser view"
+          className="max-w-full max-h-full object-contain rounded-sm"
+        />
+      </div>
+
+      {/* Status bar */}
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-t border-border">
+        <span className="relative flex h-2 w-2">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+        </span>
+        <Monitor size={12} className="text-muted-foreground" />
+        <span className="text-[10px] text-muted-foreground font-medium">Live Browser</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/chat-view.tsx
+++ b/packages/ui/src/components/chat-view.tsx
@@ -5,6 +5,7 @@ import { MessageList } from "./message-list";
 import { ChatInput } from "./chat-input";
 import type { ChatInputRecorderHandle } from "./chat-input";
 import { StatusBar } from "./status-bar";
+import { BrowserPreviewPanel } from "./browser-preview-panel";
 import { Separator } from "../ui/separator";
 import type { UseSpaceduckWs } from "../hooks/use-spaceduck-ws";
 
@@ -113,6 +114,16 @@ export function ChatView({ ws, onOpenSettings, recorderRef }: ChatViewProps) {
           recorderRef={recorderRef}
         />
       </main>
+
+      <div
+        className={`transition-all duration-300 ease-in-out overflow-hidden ${
+          ws.browserPreview ? "w-80" : "w-0"
+        }`}
+      >
+        {ws.browserPreview && (
+          <BrowserPreviewPanel preview={ws.browserPreview} />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/settings/tools-section.tsx
+++ b/packages/ui/src/components/settings/tools-section.tsx
@@ -117,6 +117,7 @@ export function ToolsSection({ cfg }: SectionProps) {
   const searxngUrl = (webSearch.searxngUrl as string | null) ?? "";
   const webAnswerEnabled = (webAnswer.enabled as boolean) ?? true;
   const browserEnabled = (browserCfg.enabled as boolean) ?? true;
+  const livePreviewEnabled = (browserCfg.livePreview as boolean) ?? false;
   const webFetchEnabled = (webFetchCfg.enabled as boolean) ?? true;
   const markerEnabled = (marker.enabled as boolean) ?? true;
 
@@ -284,7 +285,19 @@ export function ToolsSection({ cfg }: SectionProps) {
           />
         </CardHeader>
         {browserEnabled && (
-          <CardContent>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Live Preview</Label>
+                <p className="text-xs text-muted-foreground">
+                  Show real-time browser view in chat while browsing.
+                </p>
+              </div>
+              <Switch
+                checked={livePreviewEnabled}
+                onCheckedChange={(v) => patch("/tools/browser/livePreview", v)}
+              />
+            </div>
             <div className="flex items-center justify-between pt-2 border-t">
               <StatusBadge entry={brStatus} testResult={testResult["browser_navigate"]} />
               <Button


### PR DESCRIPTION
## Summary

- Adds a **live browser preview panel** that appears on the right side of the chat when the assistant is using browser tools, showing real-time page frames via Chrome DevTools Protocol `Page.startScreencast`
- The feature is **opt-in** via a new `livePreview` toggle in **Settings > Tools > Browser** (disabled by default)
- Frames are compressed JPEG (~20-50KB each) and only pushed when the page visually changes, keeping bandwidth low

## Changes

**Backend**
- `packages/config/src/schema.ts` -- Added `livePreview: boolean` (default `false`) to `BrowserSchema`
- `packages/config/src/hot-apply.ts` -- Added to hot-apply paths (no restart needed)
- `packages/tools/browser/src/browser-tool.ts` -- CDP screencast support (`startScreencast`, `stopScreencast`) + `screenshotBase64` fallback
- `packages/core/src/types/protocol.ts` -- New `browser.frame` WebSocket envelope variant
- `packages/gateway/src/browser-frame-target.ts` -- Mutable ref pattern to route frames to the active WS connection
- `packages/gateway/src/tool-registrations.ts` -- Conditionally starts screencast when `livePreview` is enabled
- `packages/gateway/src/ws-handler.ts` -- Sets/clears frame target around each agent run
- `packages/gateway/src/gateway.ts` -- Wires frame target, adds `livePreview` to tool rebuild paths

**Frontend**
- `packages/ui/src/hooks/use-spaceduck-ws.ts` -- Handles `browser.frame` events, exposes `browserPreview` state
- `packages/ui/src/components/browser-preview-panel.tsx` -- New panel with URL bar, live frame image, and pulsing indicator
- `packages/ui/src/components/chat-view.tsx` -- Panel slides in on the right (`w-80`) with smooth transition
- `packages/ui/src/components/settings/tools-section.tsx` -- Live Preview toggle in Browser card

**Docs**
- `docs/tools/browser.mdx` -- New "Live Preview" section

## Test plan

- [ ] Enable live preview in Settings > Tools > Browser
- [ ] Ask the assistant to browse a website (e.g. "go to example.com and tell me what's there")
- [ ] Verify the preview panel appears on the right with the live browser view
- [ ] Verify the panel dismisses when the assistant finishes responding
- [ ] Verify toggling live preview off stops frame streaming
- [ ] Verify the setting persists across gateway restarts (stored in config)
- [ ] Verify no frames are sent when livePreview is disabled (default)


Made with [Cursor](https://cursor.com)