### PR TITLE
test(browser): add tests for live preview feature

### DIFF
--- a/packages/config/src/__tests__/hot-apply.test.ts
+++ b/packages/config/src/__tests__/hot-apply.test.ts
@@ -15,6 +15,7 @@ describe("HOT_APPLY_PATHS", () => {
     expect(HOT_APPLY_PATHS.has("/onboarding/completedAt")).toBe(true);
     expect(HOT_APPLY_PATHS.has("/onboarding/skippedAt")).toBe(true);
     expect(HOT_APPLY_PATHS.has("/onboarding/versionCompleted")).toBe(true);
+    expect(HOT_APPLY_PATHS.has("/tools/browser/livePreview")).toBe(true);
   });
 
   test("does NOT contain restart-required paths", () => {

--- a/packages/config/src/__tests__/schema.test.ts
+++ b/packages/config/src/__tests__/schema.test.ts
@@ -245,11 +245,24 @@ describe("BrowserSchema and WebFetchSchema", () => {
     expect(config.tools.browser.enabled).toBe(true);
   });
 
+  test("browser livePreview defaults to false", () => {
+    const config = SpaceduckConfigSchema.parse({});
+    expect(config.tools.browser.livePreview).toBe(false);
+  });
+
   test("browser can be disabled", () => {
     const config = SpaceduckConfigSchema.parse({
       tools: { browser: { enabled: false } },
     });
     expect(config.tools.browser.enabled).toBe(false);
+  });
+
+  test("browser livePreview can be enabled", () => {
+    const config = SpaceduckConfigSchema.parse({
+      tools: { browser: { livePreview: true } },
+    });
+    expect(config.tools.browser.livePreview).toBe(true);
+    expect(config.tools.browser.enabled).toBe(true);
   });
 
   test("webFetch defaults to enabled", () => {

--- a/packages/gateway/src/__tests__/browser-frame-target.test.ts
+++ b/packages/gateway/src/__tests__/browser-frame-target.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, mock } from "bun:test";
+import { createBrowserFrameTarget } from "../browser-frame-target";
+
+function createMockWs() {
+  const calls: string[] = [];
+  return {
+    ws: { send(data: string) { calls.push(data); } },
+    calls,
+  };
+}
+
+describe("createBrowserFrameTarget", () => {
+  it("onFrame does nothing when target.ws is null", () => {
+    const { onFrame } = createBrowserFrameTarget();
+    onFrame({ base64: "abc", format: "jpeg", url: "https://example.com" });
+  });
+
+  it("onFrame sends browser.frame envelope when ws is set", () => {
+    const { target, onFrame } = createBrowserFrameTarget();
+    const { ws, calls } = createMockWs();
+    target.ws = ws;
+    target.requestId = "req-42";
+
+    onFrame({ base64: "AQID", format: "jpeg", url: "https://example.com" });
+
+    expect(calls).toHaveLength(1);
+    const envelope = JSON.parse(calls[0]);
+    expect(envelope).toEqual({
+      v: 1,
+      type: "browser.frame",
+      requestId: "req-42",
+      data: "AQID",
+      format: "jpeg",
+      url: "https://example.com",
+    });
+  });
+
+  it("onFrame sends closed envelope", () => {
+    const { target, onFrame } = createBrowserFrameTarget();
+    const { ws, calls } = createMockWs();
+    target.ws = ws;
+    target.requestId = "req-99";
+
+    onFrame({ closed: true });
+
+    expect(calls).toHaveLength(1);
+    const envelope = JSON.parse(calls[0]);
+    expect(envelope).toEqual({
+      v: 1,
+      type: "browser.frame",
+      requestId: "req-99",
+      closed: true,
+    });
+  });
+
+  it("clearing target.ws stops delivery", () => {
+    const { target, onFrame } = createBrowserFrameTarget();
+    const { ws, calls } = createMockWs();
+    target.ws = ws;
+    target.requestId = "req-1";
+
+    onFrame({ base64: "first", format: "jpeg", url: "https://a.com" });
+    expect(calls).toHaveLength(1);
+
+    target.ws = null;
+    onFrame({ base64: "second", format: "jpeg", url: "https://b.com" });
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add config schema tests verifying `livePreview` defaults to `false` and can be toggled on
- Add hot-apply path assertion for `/tools/browser/livePreview`
- Add BrowserTool integration tests for `screenshotBase64`, `currentUrl`, `startScreencast`/`stopScreencast`
- Add `BrowserFrameTarget` unit tests for WS envelope routing, closed signals, and null-safety

## Test plan

- [x] All 13 new tests pass locally on macOS
- [x] CI passes on both Ubuntu and macOS


Made with [Cursor](https://cursor.com)